### PR TITLE
Set the linter to a specific version

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "rimraf": "^2.5.1",
     "sinon": "~1.14.0",
     "uglify-js": "^2.6.1",
-    "videojs-standard": "^4.0.0",
+    "videojs-standard": "4.0.2",
     "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
This is to avoid breaking the build if there is a subtle breaking rule change.