### PR TITLE
Remove dependance on lodash and save lots o' bytes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015-loose"],
+  "plugins": ["transform-object-assign"]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-loose"],
-  "plugins": ["transform-object-assign"]
+	"presets": ["es2015"],
+	"plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "m3u8-parser",
   "version": "1.2.0",
   "description": "m3u8 parser",
+  "jsnext:main": "src/index.js",
   "main": "es5/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -83,12 +83,14 @@
     "src/",
     "test/"
   ],
-  "dependencies": {
-    "lodash-compat": "^3.10.2"
-  },
+  "dependencies": {},
   "devDependencies": {
-    "babel": "^5.8.35",
-    "babelify": "^6.4.0",
+    "babel": "^6.5.2",
+    "babel-cli": "^6.11.4",
+    "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015-loose": "^7.0.0",
+    "babelify": "^7.3.0",
     "bannerize": "^1.0.2",
     "bluebird": "^3.2.2",
     "browserify": "^12.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,12 @@ import LineStream from './line-stream';
 import ParseStream from './parse-stream';
 import Parser from './parser';
 
+export {
+  LineStream,
+  ParseStream,
+  Parser
+};
+
 export default {
   LineStream,
   ParseStream,

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,7 @@ import LineStream from './line-stream';
 import ParseStream from './parse-stream';
 import Parser from './parser';
 
-export {
-  LineStream,
-  ParseStream,
-  Parser
-};
-
-export default {
+module.exports = {
   LineStream,
   ParseStream,
   Parser

--- a/src/parser.js
+++ b/src/parser.js
@@ -4,7 +4,6 @@
 import Stream from './stream' ;
 import LineStream from './line-stream';
 import ParseStream from './parse-stream';
-import merge from 'lodash-compat/object/merge';
 
 /**
  * A parser for M3U8 files. The current interpretation of the input is
@@ -210,8 +209,7 @@ export default class Parser extends Stream {
               if (!currentUri.attributes) {
                 currentUri.attributes = {};
               }
-              currentUri.attributes = merge(currentUri.attributes,
-                                                   entry.attributes);
+              Object.assign(currentUri.attributes, entry.attributes);
             },
             media() {
               this.manifest.mediaGroups =


### PR DESCRIPTION
* upgrade to babel 6 to use transform-object-assign
* remove the need for lodash-merge and reduce size by ~5000kb in gzip form