### PR TITLE
Necessary change to process #ZEN-TOTAL-DURATION tag

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -102,7 +102,7 @@ export default class ParseStream extends Stream {
     }
 
     // Comments
-    if (line.indexOf('#EXT') !== 0) {
+    if ((line.indexOf('#EXT') !== 0) && (line.indexOf('#ZEN') !== 0)){
       this.trigger('data', {
         type: 'comment',
         text: line.slice(1)

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -102,7 +102,7 @@ export default class ParseStream extends Stream {
     }
 
     // Comments
-    if ((line.indexOf('#EXT') !== 0) && (line.indexOf('#ZEN') !== 0)){
+    if ((line.indexOf('#EXT') !== 0) && (line.indexOf('#ZEN') !== 0)) {
       this.trigger('data', {
         type: 'comment',
         text: line.slice(1)


### PR DESCRIPTION
If you do not do something like this the #ZEN-TOTAL-DURATION tag will be never processed.
Another possible solution is to remove that tag if nobody uses it