### PR TITLE
fix: Include the babel ES3 tranform to support IE8

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-	"presets": ["es2015"],
+	"presets": [ "es3", ["es2015"] ],
 	"plugins": ["transform-object-assign"]
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-loose": "^7.0.0",
+    "babel-preset-es3": "^1.0.1",
     "babelify": "^7.3.0",
     "bannerize": "^1.0.2",
     "bluebird": "^3.2.2",


### PR DESCRIPTION
It looks like the latest release of this project will break in IE8 because of `.default`, including the ES3 preset to fix that.