### PR TITLE
Forcing ':' on standard tags

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -24,9 +24,14 @@ const attributeSeparator = function() {
  * @param {String} attributes the attibute line to parse
  */
 const parseAttributes = function(attributes) {
+  const result = {};
+
+  if (!attributes) {
+    return result;
+  }
+
   // split the string using attributes as the separator
   const attrs = attributes.split(attributeSeparator());
-  const result = {};
   let i = attrs.length;
   let attr;
 

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -130,7 +130,7 @@ export default class ParseStream extends Stream {
       });
       return;
     }
-    match = (/^#EXTINF:?([0-9\.]*)?,?(.*)?$/).exec(line);
+    match = (/^#EXTINF:([0-9\.]*)?,?(.*)?$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -145,7 +145,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-TARGETDURATION:?([0-9.]*)?/).exec(line);
+    match = (/^#EXT-X-TARGETDURATION:([0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -157,7 +157,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#ZEN-TOTAL-DURATION:?([0-9.]*)?/).exec(line);
+    match = (/^#ZEN-TOTAL-DURATION:([0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -169,7 +169,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-VERSION:?([0-9.]*)?/).exec(line);
+    match = (/^#EXT-X-VERSION:([0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -181,7 +181,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-MEDIA-SEQUENCE:?(\-?[0-9.]*)?/).exec(line);
+    match = (/^#EXT-X-MEDIA-SEQUENCE:(\-?[0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -193,7 +193,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-DISCONTINUITY-SEQUENCE:?(\-?[0-9.]*)?/).exec(line);
+    match = (/^#EXT-X-DISCONTINUITY-SEQUENCE:(\-?[0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -205,7 +205,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-PLAYLIST-TYPE:?(.*)?$/).exec(line);
+    match = (/^#EXT-X-PLAYLIST-TYPE:(.*)?$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -217,7 +217,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-BYTERANGE:?([0-9.]*)?@?([0-9.]*)?/).exec(line);
+    match = (/^#EXT-X-BYTERANGE:([0-9.]*)?@?([0-9.]*)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -232,7 +232,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-ALLOW-CACHE:?(YES|NO)?/).exec(line);
+    match = (/^#EXT-X-ALLOW-CACHE:(YES|NO)?/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -244,7 +244,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-MAP:?(.*)$/).exec(line);
+    match = (/^#EXT-X-MAP:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -273,7 +273,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-STREAM-INF:?(.*)$/).exec(line);
+    match = (/^#EXT-X-STREAM-INF:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -304,7 +304,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-MEDIA:?(.*)$/).exec(line);
+    match = (/^#EXT-X-MEDIA:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -332,7 +332,7 @@ export default class ParseStream extends Stream {
       });
       return;
     }
-    match = (/^#EXT-X-PROGRAM-DATE-TIME:?(.*)$/).exec(line);
+    match = (/^#EXT-X-PROGRAM-DATE-TIME:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -345,7 +345,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-KEY:?(.*)$/).exec(line);
+    match = (/^#EXT-X-KEY:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',
@@ -370,7 +370,7 @@ export default class ParseStream extends Stream {
       this.trigger('data', event);
       return;
     }
-    match = (/^#EXT-X-START:?(.*)$/).exec(line);
+    match = (/^#EXT-X-START:(.*)$/).exec(line);
     if (match) {
       event = {
         type: 'tag',

--- a/test/m3u8.test.js
+++ b/test/m3u8.test.js
@@ -171,7 +171,7 @@ QUnit.test('parses #EXTM3U tags', function(assert) {
 
 // #EXTINF
 QUnit.test('parses minimal #EXTINF tags', function(assert) {
-  const manifest = '#EXTINF\n';
+  const manifest = '#EXTINF:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -244,7 +244,7 @@ QUnit.test('parses #EXTINF tags with carriage returns', function(assert) {
 
 // #EXT-X-TARGETDURATION
 QUnit.test('parses minimal #EXT-X-TARGETDURATION tags', function(assert) {
-  const manifest = '#EXT-X-TARGETDURATION\n';
+  const manifest = '#EXT-X-TARGETDURATION:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -304,7 +304,7 @@ QUnit.test('parses #EXT-X-VERSION with a version', function(assert) {
 
 // #EXT-X-MEDIA-SEQUENCE
 QUnit.test('parses minimal #EXT-X-MEDIA-SEQUENCE tags', function(assert) {
-  const manifest = '#EXT-X-MEDIA-SEQUENCE\n';
+  const manifest = '#EXT-X-MEDIA-SEQUENCE:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -378,7 +378,7 @@ QUnit.test('parses #EXT-X-PLAYLIST-TYPE with mutability info', function(assert) 
 
 // #EXT-X-BYTERANGE
 QUnit.test('parses minimal #EXT-X-BYTERANGE tags', function(assert) {
-  const manifest = '#EXT-X-BYTERANGE\n';
+  const manifest = '#EXT-X-BYTERANGE:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -506,7 +506,7 @@ QUnit.test('parses #EXT-X-MAP tags with arbitrary attributes', function(assert) 
 });
 // #EXT-X-STREAM-INF
 QUnit.test('parses minimal #EXT-X-STREAM-INF tags', function(assert) {
-  const manifest = '#EXT-X-STREAM-INF\n';
+  const manifest = '#EXT-X-STREAM-INF:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -521,7 +521,7 @@ QUnit.test('parses minimal #EXT-X-STREAM-INF tags', function(assert) {
 });
 // #EXT-X-PROGRAM-DATE-TIME
 QUnit.test('parses minimal EXT-X-PROGRAM-DATE-TIME tags', function(assert) {
-  const manifest = '#EXT-X-PROGRAM-DATE-TIME\n';
+  const manifest = '#EXT-X-PROGRAM-DATE-TIME:\n';
   let element;
 
   this.parseStream.on('data', function(elem) {
@@ -709,14 +709,6 @@ QUnit.test('parses lightly-broken #EXT-X-KEY tags', function(assert) {
   assert.strictEqual(element.attributes.URI,
                      'https://example.com/single-quote',
                      'parsed a single-quoted uri');
-
-  element = null;
-  manifest = '#EXT-X-KEYURI="https://example.com/key",METHOD=AES-128\n';
-  this.lineStream.push(manifest);
-  assert.strictEqual(element.tagType, 'key', 'parsed the tag type');
-  assert.strictEqual(element.attributes.URI,
-                     'https://example.com/key',
-                     'inferred a colon after the tag type');
 
   element = null;
   manifest = '#EXT-X-KEY:  URI =  "https://example.com/key",METHOD=AES-128\n';


### PR DESCRIPTION
To fix issues: https://github.com/videojs/m3u8-parser/issues/22

Forcing parser to recognize standard tags only when they end with ':'. This will prevent detecting, by mistake, tags that start with the same string.