### PR TITLE
chore: add NodeJS support for encrypted playlists

### DIFF
--- a/src/utils/decode.js
+++ b/src/utils/decode.js
@@ -1,7 +1,9 @@
 import window from 'global/window';
 
 export default function decodeB64ToUint8Array(b64Text) {
-  const decodedString = window.atob(b64Text || '');
+  const decodedString = window.atob === undefined ?
+    Buffer.from(b64Text || '', 'base64').toString('binary') :
+    window.atob(b64Text || '');
   const array = new Uint8Array(decodedString.length);
 
   for (let i = 0; i < decodedString.length; i++) {


### PR DESCRIPTION
Currently if you try to parse a playlist with `#EXT-X-KEY` tags it will fail, since `decodeB64ToUint8Array` uses a `window.atob` function which does not exist in NodeJS.

Added a check if the function is undefined, and use the `Buffer.from` implementation from NodeJS. 
As far as I have seen, `Buffer.from` exists since NodeJS 4.x
Browser support is, of course, unchanged.