### PR TITLE
Fix default EXT-X-BYTERANGE offset to start after the previous segment

### DIFF
--- a/test/fixtures/m3u8/byteRange.json
+++ b/test/fixtures/m3u8/byteRange.json
@@ -20,7 +20,7 @@
     {
       "byterange": {
         "length": 713084,
-        "offset": 0
+        "offset": 1110328
       },
       "duration": 10,
       "timeline": 0,


### PR DESCRIPTION
The default value for EXT-X-BYTERANGE is defined by the spec as the first byte
after the previous segment. Prior to this change, the default set by m3u8-parser
was 0.