### PR TITLE
feat: add support for #EXT-X-SERVER-CONTROL

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -498,6 +498,28 @@ export default class ParseStream extends Stream {
         this.trigger('data', event);
         return;
       }
+      match = (/^#EXT-X-SERVER-CONTROL:(.*)$/).exec(newLine);
+      if (match && match[1]) {
+        event = {
+          type: 'tag',
+          tagType: 'server-control'
+        };
+        event.attributes = parseAttributes(match[1]);
+        ['CAN-SKIP-UNTIL', 'PART-HOLD-BACK', 'HOLD-BACK'].forEach(function(key) {
+          if (event.attributes.hasOwnProperty(key)) {
+            event.attributes[key] = parseFloat(event.attributes[key]);
+          }
+        });
+
+        ['CAN-SKIP-DATERANGES', 'CAN-BLOCK-RELOAD'].forEach(function(key) {
+          if (event.attributes.hasOwnProperty(key)) {
+            event.attributes[key] = (/YES/).test(event.attributes[key]);
+          }
+        });
+
+        this.trigger('data', event);
+        return;
+      }
 
       // unknown tag type
       this.trigger('data', {

--- a/src/parser.js
+++ b/src/parser.js
@@ -390,6 +390,9 @@ export default class Parser extends Stream {
             'part'() {
               this.manifest.parts = this.manifest.parts || [];
               this.manifest.parts.push(entry.attributes);
+            },
+            'server-control'() {
+              this.manifest.serverControl = entry.attributes;
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/fixtures/m3u8/llhls.json
+++ b/test/fixtures/m3u8/llhls.json
@@ -183,5 +183,12 @@
       "uri": "fileSequence272.mp4"
     }
   ],
+  "serverControl": {
+    "CAN-SKIP-DATERANGES": true,
+    "CAN-BLOCK-RELOAD": true,
+    "CAN-SKIP-UNTIL": 12,
+    "PART-HOLD-BACK": 1,
+    "HOLD-BACK": 2
+  },
   "targetDuration": 4
 }

--- a/test/fixtures/m3u8/llhlsDelta.json
+++ b/test/fixtures/m3u8/llhlsDelta.json
@@ -156,5 +156,12 @@
       "bar"
     ]
   },
+  "serverControl": {
+    "CAN-SKIP-DATERANGES": true,
+    "CAN-BLOCK-RELOAD": true,
+    "CAN-SKIP-UNTIL": 12,
+    "PART-HOLD-BACK": 1,
+    "HOLD-BACK": 2
+  },
   "targetDuration": 4
 }


### PR DESCRIPTION
This pull request adds support for the `#EXT-X-SERVER-CONTROL` tag and all of the attributes currently in the specification for it.

See:
* https://developer.apple.com/documentation/http_live_streaming/enabling_low-latency_hls#3281374
* https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-4.4.3.8