### PR TITLE
feat: add support for #EXT-X-SKIP

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -3,6 +3,8 @@
  */
 import Stream from '@videojs/vhs-utils/es/stream.js';
 
+const TAB = String.fromCharCode(0x09);
+
 /**
  * "forgiving" attribute list psuedo-grammar:
  * attributes -> keyvalue (',' keyvalue)*
@@ -439,6 +441,26 @@ export default class ParseStream extends Stream {
         } else {
           event.data = '';
         }
+        this.trigger('data', event);
+        return;
+      }
+      match = (/^#EXT-X-SKIP:(.*)$/).exec(newLine);
+      if (match && match[1]) {
+        event = {
+          type: 'tag',
+          tagType: 'skip'
+        };
+        event.attributes = parseAttributes(match[1]);
+
+        if (event.attributes.hasOwnProperty('SKIPPED-SEGMENTS')) {
+          event.attributes['SKIPPED-SEGMENTS'] = parseInt(event.attributes['SKIPPED-SEGMENTS'], 10);
+        }
+
+        if (event.attributes.hasOwnProperty('RECENTLY-REMOVED-DATERANGES')) {
+          event.attributes['RECENTLY-REMOVED-DATERANGES'] =
+            event.attributes['RECENTLY-REMOVED-DATERANGES'].split(TAB);
+        }
+
         this.trigger('data', event);
         return;
       }

--- a/src/parser.js
+++ b/src/parser.js
@@ -383,6 +383,9 @@ export default class Parser extends Stream {
             },
             'cue-in'() {
               currentUri.cueIn = entry.data;
+            },
+            'skip'() {
+              this.manifest.skip = entry.attributes;
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/fixtures/m3u8/llhlsDelta.json
+++ b/test/fixtures/m3u8/llhlsDelta.json
@@ -29,5 +29,12 @@
       "uri": "fileSequence272.mp4"
     }
   ],
+  "skip": {
+    "SKIPPED-SEGMENTS": 3,
+    "RECENTLY-REMOVED-DATERANGES": [
+      "foo",
+      "bar"
+    ]
+  },
   "targetDuration": 4
 }


### PR DESCRIPTION
This pull request adds support for the `#EXT-X-SKIP` tag and all of the attributes currently in the specification for it.

See:
* https://developer.apple.com/documentation/http_live_streaming/enabling_low-latency_hls#3282433
* https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-4.4.5.2