### PR TITLE
feat: add support for #EXT-X-PRELOAD-HINT

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -499,6 +499,23 @@ export default class ParseStream extends Stream {
         return;
       }
 
+      match = (/^#EXT-X-PRELOAD-HINT:(.*)$/).exec(newLine);
+      if (match && match[1]) {
+        event = {
+          type: 'tag',
+          tagType: 'preload-hint'
+        };
+        event.attributes = parseAttributes(match[1]);
+        ['BYTERANGE-START', 'BYTERANGE-LENGTH'].forEach(function(key) {
+          if (event.attributes.hasOwnProperty(key)) {
+            event.attributes[key] = parseInt(event.attributes[key], 10);
+          }
+        });
+
+        this.trigger('data', event);
+        return;
+      }
+
       // unknown tag type
       this.trigger('data', {
         type: 'tag',

--- a/src/parser.js
+++ b/src/parser.js
@@ -390,6 +390,10 @@ export default class Parser extends Stream {
             'part'() {
               this.manifest.parts = this.manifest.parts || [];
               this.manifest.parts.push(entry.attributes);
+            },
+            'preload-hint'() {
+              this.manifest.preloadHints = this.manifest.preloadHints || [];
+              this.manifest.preloadHints.push(entry.attributes);
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/fixtures/m3u8/llhls.json
+++ b/test/fixtures/m3u8/llhls.json
@@ -5,6 +5,10 @@
   "discontinuitySequence": 0,
   "discontinuityStarts": [],
   "mediaSequence": 266,
+  "preloadHints": [
+    {"TYPE": "PART", "URI": "filePart273.3.mp4"},
+    {"TYPE": "PART", "URI": "filePart273.4.mp4"}
+  ],
   "parts": [
     {
       "DURATION": 0.33334,

--- a/test/fixtures/m3u8/llhlsDelta.json
+++ b/test/fixtures/m3u8/llhlsDelta.json
@@ -5,6 +5,10 @@
   "discontinuitySequence": 0,
   "discontinuityStarts": [],
   "mediaSequence": 266,
+  "preloadHints": [
+    {"TYPE": "PART", "URI": "filePart273.4.mp4"},
+    {"TYPE": "PART", "URI": "filePart273.5.mp4"}
+  ],
   "parts": [
     {
       "DURATION": 0.33334,


### PR DESCRIPTION
This pull request adds support for the `#EXT-X-PRELOAD-HINT` tag and all of the attributes currently in the specification for it.

See:
* https://developer.apple.com/documentation/http_live_streaming/enabling_low-latency_hls#3526694
* https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-4.4.5.3