### PR TITLE
feat: add support for #EXT-X-RENDITION-REPORT

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -515,6 +515,22 @@ export default class ParseStream extends Stream {
         this.trigger('data', event);
         return;
       }
+      match = (/^#EXT-X-RENDITION-REPORT:(.*)$/).exec(newLine);
+      if (match && match[1]) {
+        event = {
+          type: 'tag',
+          tagType: 'rendition-report'
+        };
+        event.attributes = parseAttributes(match[1]);
+        ['LAST-MSN', 'LAST-PART'].forEach(function(key) {
+          if (event.attributes.hasOwnProperty(key)) {
+            event.attributes[key] = parseInt(event.attributes[key], 10);
+          }
+        });
+
+        this.trigger('data', event);
+        return;
+      }
 
       // unknown tag type
       this.trigger('data', {

--- a/src/parser.js
+++ b/src/parser.js
@@ -394,6 +394,10 @@ export default class Parser extends Stream {
             'preload-hint'() {
               this.manifest.preloadHints = this.manifest.preloadHints || [];
               this.manifest.preloadHints.push(entry.attributes);
+            },
+            'rendition-report'() {
+              this.manifest.renditionReports = this.manifest.renditionReports || [];
+              this.manifest.renditionReports.push(entry.attributes);
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/fixtures/m3u8/llhls.json
+++ b/test/fixtures/m3u8/llhls.json
@@ -9,6 +9,10 @@
     {"TYPE": "PART", "URI": "filePart273.3.mp4"},
     {"TYPE": "PART", "URI": "filePart273.4.mp4"}
   ],
+  "renditionReports": [
+    {"LAST-MSN": 273, "LAST-PART": 2, "URI": "../1M/waitForMSN.php"},
+    {"LAST-MSN": 273, "LAST-PART": 1, "URI": "../4M/waitForMSN.php"}
+  ],
   "parts": [
     {
       "DURATION": 0.33334,

--- a/test/fixtures/m3u8/llhlsDelta.json
+++ b/test/fixtures/m3u8/llhlsDelta.json
@@ -9,6 +9,10 @@
     {"TYPE": "PART", "URI": "filePart273.4.mp4"},
     {"TYPE": "PART", "URI": "filePart273.5.mp4"}
   ],
+  "renditionReports": [
+    {"LAST-MSN": 273, "LAST-PART": 3, "URI": "../1M/waitForMSN.php"},
+    {"LAST-MSN": 273, "LAST-PART": 3, "URI": "../4M/waitForMSN.php"}
+  ],
   "parts": [
     {
       "DURATION": 0.33334,


### PR DESCRIPTION
This pull request adds support for the `#EXT-X-RENDITION-REPORT` tag and all of the attributes currently in the specification for it.

See:
* https://developer.apple.com/documentation/http_live_streaming/enabling_low-latency_hls#3282435
* https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-08#section-4.4.5.4