### PR TITLE
feat: add version parsing and remove totalduration

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -76,6 +76,11 @@ export default class Parser extends Stream {
         tag() {
           // switch based on the tag type
           (({
+            version() {
+              if (entry.version) {
+                this.manifest.version = entry.version;
+              }
+            },
             'allow-cache'() {
               this.manifest.allowCache = entry.allowed;
               if (!('allowed' in entry)) {
@@ -353,15 +358,6 @@ export default class Parser extends Stream {
                 return;
               }
               this.manifest.targetDuration = entry.duration;
-            },
-            totalduration() {
-              if (!isFinite(entry.duration) || entry.duration < 0) {
-                this.trigger('warn', {
-                  message: 'ignoring invalid total duration: ' + entry.duration
-                });
-                return;
-              }
-              this.manifest.totalDuration = entry.duration;
             },
             start() {
               if (!entry.attributes || isNaN(entry.attributes['TIME-OFFSET'])) {

--- a/test/fixtures/integration/allowCache.js
+++ b/test/fixtures/integration/allowCache.js
@@ -160,5 +160,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/allowCacheInvalid.js
+++ b/test/fixtures/integration/allowCacheInvalid.js
@@ -16,5 +16,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/byteRange.js
+++ b/test/fixtures/integration/byteRange.js
@@ -156,5 +156,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 3
 };

--- a/test/fixtures/integration/disallowCache.js
+++ b/test/fixtures/integration/disallowCache.js
@@ -16,5 +16,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/disc-sequence.js
+++ b/test/fixtures/integration/disc-sequence.js
@@ -27,5 +27,6 @@ module.exports = {
   ],
   targetDuration: 19,
   endList: true,
-  discontinuityStarts: [2]
+  discontinuityStarts: [2],
+  version: 3
 };

--- a/test/fixtures/integration/discontinuity.js
+++ b/test/fixtures/integration/discontinuity.js
@@ -54,5 +54,6 @@ module.exports = {
   ],
   targetDuration: 19,
   endList: true,
-  discontinuityStarts: [2, 4, 7]
+  discontinuityStarts: [2, 4, 7],
+  version: 3
 };

--- a/test/fixtures/integration/emptyAllowCache.js
+++ b/test/fixtures/integration/emptyAllowCache.js
@@ -16,5 +16,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/encrypted.js
+++ b/test/fixtures/integration/encrypted.js
@@ -56,5 +56,6 @@ module.exports = {
       uri: 'http://media.example.com/fileSequence53-B.ts'
     }
   ],
-  targetDuration: 15
+  targetDuration: 15,
+  version: 3
 };

--- a/test/fixtures/integration/extinf.js
+++ b/test/fixtures/integration/extinf.js
@@ -160,5 +160,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 3
 };

--- a/test/fixtures/integration/fmp4.js
+++ b/test/fixtures/integration/fmp4.js
@@ -39,5 +39,6 @@ module.exports = {
       }
     }
   ],
-  endList: true
+  endList: true,
+  version: 7
 };

--- a/test/fixtures/integration/invalidAllowCache.js
+++ b/test/fixtures/integration/invalidAllowCache.js
@@ -16,5 +16,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/invalidTargetDuration.js
+++ b/test/fixtures/integration/invalidTargetDuration.js
@@ -159,5 +159,6 @@ module.exports = {
   ],
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -201,5 +201,6 @@ module.exports = {
     'PART-HOLD-BACK': 1,
     'HOLD-BACK': 2
   },
-  targetDuration: 4
+  targetDuration: 4,
+  version: 6
 };

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -174,5 +174,6 @@ module.exports = {
     'PART-HOLD-BACK': 1,
     'HOLD-BACK': 2
   },
-  targetDuration: 4
+  targetDuration: 4,
+  version: 9
 };

--- a/test/fixtures/integration/master-fmp4.js
+++ b/test/fixtures/integration/master-fmp4.js
@@ -460,5 +460,6 @@ module.exports = {
     timeline: 0,
     uri: 'v1/prog_index.m3u8'
   }],
-  segments: []
+  segments: [],
+  version: 6
 };

--- a/test/fixtures/integration/missingExtinf.js
+++ b/test/fixtures/integration/missingExtinf.js
@@ -22,5 +22,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 3
 };

--- a/test/fixtures/integration/playlist.js
+++ b/test/fixtures/integration/playlist.js
@@ -160,5 +160,6 @@ module.exports = {
   targetDuration: 10,
   endList: true,
   discontinuitySequence: 0,
-  discontinuityStarts: []
+  discontinuityStarts: [],
+  version: 4
 };

--- a/test/fixtures/integration/start.js
+++ b/test/fixtures/integration/start.js
@@ -31,5 +31,6 @@ module.exports = {
   start: {
     timeOffset: 10.3,
     precise: false
-  }
+  },
+  version: 3
 };


### PR DESCRIPTION
We never used the `#EXT-X-VERSION` even though we parsed it. `totalduration` doesn't exist in parse-stream and there isn't anything equivalent in the spec.