### PR TITLE
feat: add raw list of segment lines to manifest

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -118,7 +118,8 @@ export default class ParseStream extends Stream {
     if (line[0] !== '#') {
       this.trigger('data', {
         type: 'uri',
-        uri: line
+        uri: line,
+        raw: line
       });
       return;
     }
@@ -146,7 +147,8 @@ export default class ParseStream extends Stream {
       if (newLine.indexOf('#EXT') !== 0) {
         this.trigger('data', {
           type: 'comment',
-          text: newLine.slice(1)
+          text: newLine.slice(1),
+          raw: newLine
         });
         return;
       }
@@ -160,7 +162,8 @@ export default class ParseStream extends Stream {
       if (match) {
         this.trigger('data', {
           type: 'tag',
-          tagType: 'm3u'
+          tagType: 'm3u',
+          raw: newLine
         });
         return;
       }
@@ -168,7 +171,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'inf'
+          tagType: 'inf',
+          raw: newLine
         };
         if (match[1]) {
           event.duration = parseFloat(match[1]);
@@ -183,7 +187,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'targetduration'
+          tagType: 'targetduration',
+          raw: newLine
         };
         if (match[1]) {
           event.duration = parseInt(match[1], 10);
@@ -195,7 +200,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'version'
+          tagType: 'version',
+          raw: newLine
         };
         if (match[1]) {
           event.version = parseInt(match[1], 10);
@@ -207,7 +213,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'media-sequence'
+          tagType: 'media-sequence',
+          raw: newLine
         };
         if (match[1]) {
           event.number = parseInt(match[1], 10);
@@ -219,7 +226,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'discontinuity-sequence'
+          tagType: 'discontinuity-sequence',
+          raw: newLine
         };
         if (match[1]) {
           event.number = parseInt(match[1], 10);
@@ -231,7 +239,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'playlist-type'
+          tagType: 'playlist-type',
+          raw: newLine
         };
         if (match[1]) {
           event.playlistType = match[1];
@@ -243,7 +252,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = Object.assign(parseByterange(match[1]), {
           type: 'tag',
-          tagType: 'byterange'
+          tagType: 'byterange',
+          raw: newLine
         });
         this.trigger('data', event);
         return;
@@ -252,7 +262,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'allow-cache'
+          tagType: 'allow-cache',
+          raw: newLine
         };
         if (match[1]) {
           event.allowed = !(/NO/).test(match[1]);
@@ -264,7 +275,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'map'
+          tagType: 'map',
+          raw: newLine
         };
 
         if (match[1]) {
@@ -285,7 +297,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'stream-inf'
+          tagType: 'stream-inf',
+          raw: newLine
         };
         if (match[1]) {
           event.attributes = parseAttributes(match[1]);
@@ -316,7 +329,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'media'
+          tagType: 'media',
+          raw: newLine
         };
         if (match[1]) {
           event.attributes = parseAttributes(match[1]);
@@ -328,7 +342,8 @@ export default class ParseStream extends Stream {
       if (match) {
         this.trigger('data', {
           type: 'tag',
-          tagType: 'endlist'
+          tagType: 'endlist',
+          raw: newLine
         });
         return;
       }
@@ -336,7 +351,8 @@ export default class ParseStream extends Stream {
       if (match) {
         this.trigger('data', {
           type: 'tag',
-          tagType: 'discontinuity'
+          tagType: 'discontinuity',
+          raw: newLine
         });
         return;
       }
@@ -344,7 +360,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'program-date-time'
+          tagType: 'program-date-time',
+          raw: newLine
         };
         if (match[1]) {
           event.dateTimeString = match[1];
@@ -357,7 +374,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'key'
+          tagType: 'key',
+          raw: newLine
         };
         if (match[1]) {
           event.attributes = parseAttributes(match[1]);
@@ -382,7 +400,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'start'
+          tagType: 'start',
+          raw: newLine
         };
         if (match[1]) {
           event.attributes = parseAttributes(match[1]);
@@ -397,7 +416,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'cue-out-cont'
+          tagType: 'cue-out-cont',
+          raw: newLine
         };
         if (match[1]) {
           event.data = match[1];
@@ -411,7 +431,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'cue-out'
+          tagType: 'cue-out',
+          raw: newLine
         };
         if (match[1]) {
           event.data = match[1];
@@ -425,7 +446,8 @@ export default class ParseStream extends Stream {
       if (match) {
         event = {
           type: 'tag',
-          tagType: 'cue-in'
+          tagType: 'cue-in',
+          raw: newLine
         };
         if (match[1]) {
           event.data = match[1];
@@ -439,7 +461,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'skip'
+          tagType: 'skip',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
 
@@ -459,7 +482,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'part'
+          tagType: 'part',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
         ['DURATION'].forEach(function(key) {
@@ -485,7 +509,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'server-control'
+          tagType: 'server-control',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
         ['CAN-SKIP-UNTIL', 'PART-HOLD-BACK', 'HOLD-BACK'].forEach(function(key) {
@@ -507,7 +532,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'part-inf'
+          tagType: 'part-inf',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
         ['PART-TARGET'].forEach(function(key) {
@@ -524,7 +550,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'preload-hint'
+          tagType: 'preload-hint',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
         ['BYTERANGE-START', 'BYTERANGE-LENGTH'].forEach(function(key) {
@@ -547,7 +574,8 @@ export default class ParseStream extends Stream {
       if (match && match[1]) {
         event = {
           type: 'tag',
-          tagType: 'rendition-report'
+          tagType: 'rendition-report',
+          raw: newLine
         };
         event.attributes = parseAttributes(match[1]);
         ['LAST-MSN', 'LAST-PART'].forEach(function(key) {
@@ -563,7 +591,8 @@ export default class ParseStream extends Stream {
       // unknown tag type
       this.trigger('data', {
         type: 'tag',
-        data: newLine.slice(4)
+        data: newLine.slice(4),
+        raw: newLine
       });
     });
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -101,7 +101,7 @@ export default class Parser extends Stream {
     const self = this;
     /* eslint-enable consistent-this */
     const uris = [];
-    let currentUri = {};
+    let currentUri = { raw: [] };
     // if specified, the active EXT-X-MAP definition
     let currentMap;
     // if specified, the active decryption key
@@ -178,6 +178,7 @@ export default class Parser extends Stream {
               }
             },
             byterange() {
+              currentUri.raw.push(entry.raw);
               const byterange = {};
 
               if ('length' in entry) {
@@ -208,6 +209,7 @@ export default class Parser extends Stream {
               this.manifest.endList = true;
             },
             inf() {
+              currentUri.raw.push(entry.raw);
               if (!('mediaSequence' in this.manifest)) {
                 this.manifest.mediaSequence = 0;
                 this.trigger('info', {
@@ -379,6 +381,7 @@ export default class Parser extends Stream {
               }
             },
             'stream-inf'() {
+              currentUri.raw.push(entry.raw);
               this.manifest.playlists = uris;
               this.manifest.mediaGroups =
                 this.manifest.mediaGroups || defaultMediaGroups;
@@ -445,11 +448,13 @@ export default class Parser extends Stream {
               mediaGroup[entry.attributes.NAME] = rendition;
             },
             discontinuity() {
+              currentUri.raw.push(entry.raw);
               currentTimeline += 1;
               currentUri.discontinuity = true;
               this.manifest.discontinuityStarts.push(uris.length);
             },
             'program-date-time'() {
+              currentUri.raw.push(entry.raw);
               if (typeof this.manifest.dateTimeString === 'undefined') {
                 // PROGRAM-DATE-TIME is a media-segment tag, but for backwards
                 // compatibility, we add the first occurence of the PROGRAM-DATE-TIME tag
@@ -486,12 +491,15 @@ export default class Parser extends Stream {
               };
             },
             'cue-out'() {
+              currentUri.raw.push(entry.raw);
               currentUri.cueOut = entry.data;
             },
             'cue-out-cont'() {
+              currentUri.raw.push(entry.raw);
               currentUri.cueOutCont = entry.data;
             },
             'cue-in'() {
+              currentUri.raw.push(entry.raw);
               currentUri.cueIn = entry.data;
             },
             'skip'() {
@@ -504,6 +512,7 @@ export default class Parser extends Stream {
               );
             },
             'part'() {
+              currentUri.raw.push(entry.raw);
               hasParts = true;
               // parts are always specifed before a segment
               const segmentIndex = this.manifest.segments.length;
@@ -555,6 +564,7 @@ export default class Parser extends Stream {
               }
             },
             'preload-hint'() {
+              currentUri.raw.push(entry.raw);
               // parts are always specifed before a segment
               const segmentIndex = this.manifest.segments.length;
               const hint = camelCaseKeys(entry.attributes);
@@ -635,6 +645,7 @@ export default class Parser extends Stream {
           })[entry.tagType] || noop).call(self);
         },
         uri() {
+          currentUri.raw.push(entry.raw);
           currentUri.uri = entry.uri;
           uris.push(currentUri);
 
@@ -659,7 +670,7 @@ export default class Parser extends Stream {
           lastPartByterangeEnd = 0;
 
           // prepare for the next URI
-          currentUri = {};
+          currentUri = { raw: [] };
         },
         comment() {
           // comments are not important for playback
@@ -667,6 +678,7 @@ export default class Parser extends Stream {
         custom() {
           // if this is segment-level data attach the output to the segment
           if (entry.segment) {
+            currentUri.raw.push(entry.raw);
             currentUri.custom = currentUri.custom || {};
             currentUri.custom[entry.customType] = entry.data;
           // if this is manifest-level data attach to the top level manifest object

--- a/test/fixtures/integration/absoluteUris.js
+++ b/test/fixtures/integration/absoluteUris.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'http://example.com/00001.ts'
+      ],
       timeline: 0,
       uri: 'http://example.com/00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'https://example.com/00002.ts'
+      ],
       timeline: 0,
       uri: 'https://example.com/00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '//example.com/00003.ts'
+      ],
       timeline: 0,
       uri: '//example.com/00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'http://example.com/00004.ts'
+      ],
       timeline: 0,
       uri: 'http://example.com/00004.ts'
     }

--- a/test/fixtures/integration/allowCache.js
+++ b/test/fixtures/integration/allowCache.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -18,6 +23,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -27,6 +37,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:713084@1110328',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -36,6 +51,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -45,6 +65,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -54,6 +79,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -63,6 +93,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -72,6 +107,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -81,6 +121,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -90,6 +135,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -99,6 +149,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -108,6 +163,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -117,6 +177,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -126,6 +191,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -135,6 +205,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -144,6 +219,11 @@ module.exports = {
         offset: 8021772
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -153,6 +233,11 @@ module.exports = {
         offset: 8353216
       },
       duration: 1.4167,
+      raw: [
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/allowCacheInvalid.js
+++ b/test/fixtures/integration/allowCacheInvalid.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/alternateAudio.js
+++ b/test/fixtures/integration/alternateAudio.js
@@ -40,6 +40,10 @@ module.exports = {
       'CODECS': 'avc1.42e00a,mp4a.40.2',
       'AUDIO': 'audio'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=195023,CODECS=\"avc1.42e00a,mp4a.40.2\",AUDIO=\"audio\"',
+      'lo/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'lo/prog_index.m3u8'
   }, {
@@ -49,6 +53,10 @@ module.exports = {
       'CODECS': 'avc1.42e01e,mp4a.40.2',
       'AUDIO': 'audio'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=591680,CODECS=\"avc1.42e01e,mp4a.40.2\",AUDIO=\"audio\"',
+      'hi/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'hi/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/alternateVideo.js
+++ b/test/fixtures/integration/alternateVideo.js
@@ -41,6 +41,10 @@ module.exports = {
       'AUDIO': 'aac',
       'VIDEO': '500kbs'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=754857,CODECS=\"mp4a.40.2,avc1.4d401e\",VIDEO=\"500kbs\",AUDIO=\"aac\"',
+      'Angle1/500kbs/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'Angle1/500kbs/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/brightcove.js
+++ b/test/fixtures/integration/brightcove.js
@@ -10,6 +10,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=240000,RESOLUTION=396x224',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686811001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686811001&videoId=1824650741001'
     },
@@ -18,6 +22,10 @@ module.exports = {
         'PROGRAM-ID': 1,
         'BANDWIDTH': 40000
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=40000',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824683759001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824683759001&videoId=1824650741001'
     },
@@ -30,6 +38,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=440000,RESOLUTION=396x224',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686593001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686593001&videoId=1824650741001'
     },
@@ -42,6 +54,10 @@ module.exports = {
           height: 540
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1928000,RESOLUTION=960x540',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001'
     }

--- a/test/fixtures/integration/byteRange.js
+++ b/test/fixtures/integration/byteRange.js
@@ -5,6 +5,10 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -14,6 +18,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -23,6 +32,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:713084',
+        'hls_450k_video2.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video2.ts'
     },
@@ -32,6 +46,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -41,6 +60,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -50,6 +74,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -59,6 +88,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -68,6 +102,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -77,6 +116,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -86,6 +130,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -95,6 +144,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -104,6 +158,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -113,6 +172,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -122,6 +186,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -131,6 +200,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -140,6 +214,11 @@ module.exports = {
         offset: 8021772
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -149,6 +228,11 @@ module.exports = {
         offset: 8353216
       },
       duration: 1.4167,
+      raw: [
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -7,6 +7,11 @@ module.exports = {
       dateTimeString: '2016-06-22T09:20:16.166-04:00',
       dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
       duration: 10,
+      raw: [
+        '#EXT-X-PROGRAM-DATE-TIME:2016-06-22T09:20:16.166-04:00',
+        '#EXTINF:10',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -14,6 +19,11 @@ module.exports = {
       dateTimeString: '2016-06-22T09:20:26.166-04:00',
       dateTimeObject: new Date('2016-06-22T09:20:26.166-04:00'),
       duration: 10,
+      raw: [
+        '#EXT-X-PROGRAM-DATE-TIME:2016-06-22T09:20:26.166-04:00',
+        '#EXTINF:10',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/diff-init-key.js
+++ b/test/fixtures/integration/diff-init-key.js
@@ -17,6 +17,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init52.mp4'
       },
+      raw: [
+        '#EXTINF:2.833,',
+        'http://media.example.com/fileSequence52-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence52-A.m4s'
     },
@@ -33,6 +37,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init52.mp4'
       },
+      raw: [
+        '#EXTINF:15.0,',
+        'http://media.example.com/fileSequence52-B.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence52-B.m4s'
     },
@@ -49,6 +57,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init52.mp4'
       },
+      raw: [
+        '#EXTINF:13.333,',
+        'http://media.example.com/fileSequence52-C.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence52-C.m4s'
     },
@@ -65,6 +77,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init53-A.mp4'
       },
+      raw: [
+        '#EXTINF:15.0,',
+        'http://media.example.com/fileSequence53-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence53-A.m4s'
     },
@@ -83,6 +99,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init53-B.mp4'
       },
+      raw: [
+        '#EXTINF:14.0,',
+        'http://media.example.com/fileSequence53-B.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence53-B.m4s'
     },
@@ -95,6 +115,10 @@ module.exports = {
       map: {
         uri: 'http://media.example.com/init54-A.mp4'
       },
+      raw: [
+        '#EXTINF:12.0,',
+        'http://media.example.com/fileSequence54-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-A.m4s'
     },
@@ -107,6 +131,10 @@ module.exports = {
       map: {
         uri: 'http://media.example.com/init54-A.mp4'
       },
+      raw: [
+        '#EXTINF:13.0,',
+        'http://media.example.com/fileSequence54-B.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-B.m4s'
     },
@@ -119,6 +147,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init54-B.mp4'
       },
+      raw: [
+        '#EXTINF:10.0,',
+        'http://media.example.com/fileSequence54-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-A.m4s'
     },
@@ -131,6 +163,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init54-B.mp4'
       },
+      raw: [
+        '#EXTINF:11.0,',
+        'http://media.example.com/fileSequence54-B.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-B.m4s'
     },
@@ -147,6 +183,10 @@ module.exports = {
         },
         uri: 'http://media.example.com/init54-D.mp4'
       },
+      raw: [
+        '#EXTINF:4.0,',
+        'http://media.example.com/fileSequence54-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-A.m4s'
     },
@@ -155,6 +195,10 @@ module.exports = {
       map: {
         uri: 'http://media.example.com/init54-E.mp4'
       },
+      raw: [
+        '#EXTINF:12.0,',
+        'http://media.example.com/fileSequence54-A.m4s'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence54-A.m4s'
     }

--- a/test/fixtures/integration/disallowCache.js
+++ b/test/fixtures/integration/disallowCache.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/disc-sequence.js
+++ b/test/fixtures/integration/disc-sequence.js
@@ -5,22 +5,39 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '001.ts'
+      ],
       timeline: 3,
       uri: '001.ts'
     },
     {
       duration: 19,
+      raw: [
+        '#EXTINF:19,0',
+        '002.ts'
+      ],
       timeline: 3,
       uri: '002.ts'
     },
     {
       discontinuity: true,
       duration: 10,
+      raw: [
+        '#EXT-X-DISCONTINUITY',
+        '#EXTINF:10,0',
+        '003.ts'
+      ],
       timeline: 4,
       uri: '003.ts'
     },
     {
       duration: 11,
+      raw: [
+        '#EXTINF:11,0',
+        '004.ts'
+      ],
       timeline: 4,
       uri: '004.ts'
     }

--- a/test/fixtures/integration/discontinuity.js
+++ b/test/fixtures/integration/discontinuity.js
@@ -5,49 +5,88 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '001.ts'
+      ],
       timeline: 0,
       uri: '001.ts'
     },
     {
       duration: 19,
+      raw: [
+        '#EXTINF:19,0',
+        '002.ts'
+      ],
       timeline: 0,
       uri: '002.ts'
     },
     {
       discontinuity: true,
       duration: 10,
+      raw: [
+        '#EXT-X-DISCONTINUITY',
+        '#EXTINF:10,0',
+        '003.ts'
+      ],
       timeline: 1,
       uri: '003.ts'
     },
     {
       duration: 11,
+      raw: [
+        '#EXTINF:11,0',
+        '004.ts'
+      ],
       timeline: 1,
       uri: '004.ts'
     },
     {
       discontinuity: true,
       duration: 10,
+      raw: [
+        '#EXT-X-DISCONTINUITY',
+        '#EXTINF:10,0',
+        '005.ts'
+      ],
       timeline: 2,
       uri: '005.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '006.ts'
+      ],
       timeline: 2,
       uri: '006.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '007.ts'
+      ],
       timeline: 2,
       uri: '007.ts'
     },
     {
       discontinuity: true,
       duration: 10,
+      raw: [
+        '#EXT-X-DISCONTINUITY',
+        '#EXTINF:10,0',
+        '008.ts'
+      ],
       timeline: 3,
       uri: '008.ts'
     },
     {
       duration: 16,
+      raw: [
+        '#EXTINF:16,0',
+        '009.ts'
+      ],
       timeline: 3,
       uri: '009.ts'
     }

--- a/test/fixtures/integration/domainUris.js
+++ b/test/fixtures/integration/domainUris.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/00001.ts'
+      ],
       timeline: 0,
       uri: '/00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/subdir/00002.ts'
+      ],
       timeline: 0,
       uri: '/subdir/00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/00003.ts'
+      ],
       timeline: 0,
       uri: '/00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/00004.ts'
+      ],
       timeline: 0,
       uri: '/00004.ts'
     }

--- a/test/fixtures/integration/emptyAllowCache.js
+++ b/test/fixtures/integration/emptyAllowCache.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/emptyMediaSequence.js
+++ b/test/fixtures/integration/emptyMediaSequence.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/emptyPlaylistType.js
+++ b/test/fixtures/integration/emptyPlaylistType.js
@@ -4,31 +4,55 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
     },
     {
       duration: 8,
+      raw: [
+        '#EXTINF:8,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
     }

--- a/test/fixtures/integration/emptyTargetDuration.js
+++ b/test/fixtures/integration/emptyTargetDuration.js
@@ -10,6 +10,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=240000,RESOLUTION=396x224',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686811001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686811001&videoId=1824650741001'
     },
@@ -18,6 +22,10 @@ module.exports = {
         'PROGRAM-ID': 1,
         'BANDWIDTH': 40000
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=40000',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824683759001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824683759001&videoId=1824650741001'
     },
@@ -30,6 +38,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=440000,RESOLUTION=396x224',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686593001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824686593001&videoId=1824650741001'
     },
@@ -42,6 +54,10 @@ module.exports = {
           height: 540
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1928000,RESOLUTION=960x540',
+        'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001'
+      ],
       timeline: 0,
       uri: 'http://c.brightcove.com/services/mobile/streaming/index/rendition.m3u8?assetId=1824687660001&videoId=1824650741001'
     }

--- a/test/fixtures/integration/encrypted.js
+++ b/test/fixtures/integration/encrypted.js
@@ -6,6 +6,10 @@ module.exports = {
   segments: [
     {
       duration: 2.833,
+      raw: [
+        '#EXTINF:2.833,',
+        'http://media.example.com/fileSequence52-A.ts'
+      ],
       timeline: 0,
       key: {
         method: 'AES-128',
@@ -15,6 +19,10 @@ module.exports = {
     },
     {
       duration: 15,
+      raw: [
+        '#EXTINF:15.0,',
+        'http://media.example.com/fileSequence52-B.ts'
+      ],
       timeline: 0,
       key: {
         method: 'AES-128',
@@ -24,6 +32,10 @@ module.exports = {
     },
     {
       duration: 13.333,
+      raw: [
+        '#EXTINF:13.333,',
+        'http://media.example.com/fileSequence52-C.ts'
+      ],
       timeline: 0,
       key: {
         method: 'AES-128',
@@ -33,6 +45,10 @@ module.exports = {
     },
     {
       duration: 15,
+      raw: [
+        '#EXTINF:15.0,',
+        'http://media.example.com/fileSequence53-A.ts'
+      ],
       timeline: 0,
       key: {
         method: 'AES-128',
@@ -42,6 +58,10 @@ module.exports = {
     },
     {
       duration: 14,
+      raw: [
+        '#EXTINF:14.0,',
+        'http://media.example.com/fileSequence53-B.ts'
+      ],
       timeline: 0,
       key: {
         method: 'AES-128',
@@ -52,6 +72,10 @@ module.exports = {
     },
     {
       duration: 15,
+      raw: [
+        '#EXTINF:15.0,',
+        'http://media.example.com/fileSequence53-B.ts'
+      ],
       timeline: 0,
       uri: 'http://media.example.com/fileSequence53-B.ts'
     }

--- a/test/fixtures/integration/event.js
+++ b/test/fixtures/integration/event.js
@@ -5,31 +5,55 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
     },
     {
       duration: 8,
+      raw: [
+        '#EXTINF:8,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
     }

--- a/test/fixtures/integration/extXPlaylistTypeInvalidPlaylist.js
+++ b/test/fixtures/integration/extXPlaylistTypeInvalidPlaylist.js
@@ -4,6 +4,10 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     }

--- a/test/fixtures/integration/extinf.js
+++ b/test/fixtures/integration/extinf.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -18,6 +23,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:;asljasdfii11)))00,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -27,6 +37,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 5,
+      raw: [
+        '#EXTINF:5,',
+        '#EXT-X-BYTERANGE:713084@1110328',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -36,6 +51,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 9.7,
+      raw: [
+        '#EXTINF:9.7,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -45,6 +65,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -54,6 +79,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -63,6 +93,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -72,6 +107,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -81,6 +121,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -90,6 +135,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -99,6 +149,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -108,6 +163,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -117,6 +177,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -126,6 +191,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -135,6 +205,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -144,6 +219,12 @@ module.exports = {
         offset: 8021772
       },
       duration: 10,
+      raw: [
+        '#EXTINF:22,',
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -153,6 +234,10 @@ module.exports = {
         offset: 8353216
       },
       duration: 10,
+      raw: [
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/fmp4.js
+++ b/test/fixtures/integration/fmp4.js
@@ -12,6 +12,11 @@ module.exports = {
         offset: 720
       },
       duration: 6.006,
+      raw: [
+        '#EXTINF:6.00600,',
+        '#EXT-X-BYTERANGE:5666510@720',
+        'main.mp4'
+      ],
       timeline: 0,
       uri: 'main.mp4',
       map: {
@@ -28,6 +33,11 @@ module.exports = {
         offset: 5667230
       },
       duration: 6.006,
+      raw: [
+        '#EXTINF:6.00600,',
+        '#EXT-X-BYTERANGE:5861577@5667230',
+        'main.mp4'
+      ],
       timeline: 0,
       uri: 'main.mp4',
       map: {

--- a/test/fixtures/integration/invalidAllowCache.js
+++ b/test/fixtures/integration/invalidAllowCache.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/invalidMediaSequence.js
+++ b/test/fixtures/integration/invalidMediaSequence.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/invalidPlaylistType.js
+++ b/test/fixtures/integration/invalidPlaylistType.js
@@ -4,31 +4,55 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00004.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00005.ts'
     },
     {
       duration: 8,
+      raw: [
+        '#EXTINF:8,',
+        '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/haze/Haze_Mantel_President_encoded_1200-00006.ts'
     }

--- a/test/fixtures/integration/invalidTargetDuration.js
+++ b/test/fixtures/integration/invalidTargetDuration.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -18,6 +23,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -27,6 +37,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:713084@1110328',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -36,6 +51,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -45,6 +65,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -54,6 +79,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -63,6 +93,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -72,6 +107,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -81,6 +121,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -90,6 +135,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -99,6 +149,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -108,6 +163,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -117,6 +177,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -126,6 +191,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -135,6 +205,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -144,6 +219,11 @@ module.exports = {
         offset: 8021772
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -153,6 +233,11 @@ module.exports = {
         offset: 8353216
       },
       duration: 1.4167,
+      raw: [
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/liveMissingSegmentDuration.js
+++ b/test/fixtures/integration/liveMissingSegmentDuration.js
@@ -5,16 +5,26 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 8,
+      raw: [
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 8,
+      raw: [
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     }

--- a/test/fixtures/integration/liveStart30sBefore.js
+++ b/test/fixtures/integration/liveStart30sBefore.js
@@ -4,46 +4,82 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '001.ts'
+      ],
       timeline: 0,
       uri: '001.ts'
     },
     {
       duration: 19,
+      raw: [
+        '#EXTINF:19,0',
+        '002.ts'
+      ],
       timeline: 0,
       uri: '002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '003.ts'
+      ],
       timeline: 0,
       uri: '003.ts'
     },
     {
       duration: 11,
+      raw: [
+        '#EXTINF:11,0',
+        '004.ts'
+      ],
       timeline: 0,
       uri: '004.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '005.ts'
+      ],
       timeline: 0,
       uri: '005.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '006.ts'
+      ],
       timeline: 0,
       uri: '006.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '007.ts'
+      ],
       timeline: 0,
       uri: '007.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,0',
+        '008.ts'
+      ],
       timeline: 0,
       uri: '008.ts'
     },
     {
       duration: 16,
+      raw: [
+        '#EXTINF:16,0',
+        '009.ts'
+      ],
       timeline: 0,
       uri: '009.ts'
     }

--- a/test/fixtures/integration/llhls-byte-range.js
+++ b/test/fixtures/integration/llhls-byte-range.js
@@ -31,6 +31,11 @@ module.exports = {
         }
       }
     ],
+    raw: [
+      '#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"filePart273.1.mp4\",BYTERANGE-LENGTH=2000',
+      '#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"file-init.mp4\",BYTERANGE-LENGTH=5000,BYTERANGE-START=8355216',
+      '#EXT-X-PRELOAD-HINT:TYPE=FOO,URI=\"foo.mp4\",BYTERANGE-LENGTH=5000'
+    ],
     timeline: 0
   },
   segments: [
@@ -40,6 +45,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -49,6 +59,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -58,6 +73,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:713084',
+        'hls_450k_video2.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video2.ts'
     },
@@ -67,6 +87,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -76,6 +101,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -85,6 +115,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -94,6 +129,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -103,6 +143,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -112,6 +157,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -121,6 +171,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -130,6 +185,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -139,6 +199,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -148,6 +213,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -157,6 +227,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -166,6 +241,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -209,6 +289,15 @@ module.exports = {
           }
         }
       ],
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.part.ts\",BYTERANGE=45553',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.part.ts\",BYTERANGE=28823@7622329',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.part.ts\",BYTERANGE=22444',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.part.ts\",BYTERANGE=22444',
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -243,6 +332,14 @@ module.exports = {
             offset: 8096148
           }
         }
+      ],
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=45553@8021772',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=28823',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=22444',
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
       ],
       timeline: 0,
       uri: 'hls_450k_video.ts'

--- a/test/fixtures/integration/llhls-delta-byte-range.js
+++ b/test/fixtures/integration/llhls-delta-byte-range.js
@@ -41,6 +41,12 @@ module.exports = {
         }
       }
     ],
+    raw: [
+      '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=22444',
+      '#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"filePart273.1.mp4\",BYTERANGE-LENGTH=2000',
+      '#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"file-init.mp4\",BYTERANGE-LENGTH=5000,BYTERANGE-START=8377660',
+      '#EXT-X-PRELOAD-HINT:TYPE=FOO,URI=\"foo.mp4\",BYTERANGE-LENGTH=5000'
+    ],
     timeline: 0
   },
   segments: [
@@ -50,6 +56,12 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -59,6 +71,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -102,6 +119,15 @@ module.exports = {
           }
         }
       ],
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=45553',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=28823@7622329',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=22444',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=22444',
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -136,6 +162,14 @@ module.exports = {
             offset: 8096148
           }
         }
+      ],
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=45553@8021772',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=28823',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"hls_450k_video.ts\",BYTERANGE=22444',
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
       ],
       timeline: 0,
       uri: 'hls_450k_video.ts'

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -26,6 +26,13 @@ module.exports = {
       {type: 'PART', uri: 'filePart273.3.mp4'},
       {type: 'MAP', uri: 'file-init.mp4'}
     ],
+    raw: [
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.0.mp4\",INDEPENDENT=YES',
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.1.mp4\"',
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.2.mp4\"',
+      '#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"filePart273.3.mp4\"',
+      '#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"file-init.mp4\"'
+    ],
     timeline: 0
   },
   renditionReports: [
@@ -44,6 +51,11 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:13:36.106Z',
+        '#EXTINF:4.00008,',
+        'fileSequence266.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence266.mp4'
     },
@@ -52,6 +64,10 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence267.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence267.mp4'
     },
@@ -60,6 +76,10 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence268.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence268.mp4'
     },
@@ -68,6 +88,10 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence269.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence269.mp4'
     },
@@ -76,6 +100,10 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence270.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence270.mp4'
     },
@@ -84,6 +112,22 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.0.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.1.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.2.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.3.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.4.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.5.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.6.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.7.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.8.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.9.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.10.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.11.mp4\"',
+        '#EXTINF:4.00008,',
+        'fileSequence271.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence271.mp4',
       parts: [
@@ -146,6 +190,23 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      raw: [
+        '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:14:00.106Z',
+        '#EXT-X-PART:GAP=YES,DURATION=0.33334,URI=\"filePart272.a.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.b.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.c.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.d.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.e.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.f.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.g.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.h.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.i.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.j.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.k.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.l.mp4\"',
+        '#EXTINF:4.00008,',
+        'fileSequence272.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence272.mp4',
       parts: [

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -6,6 +6,14 @@ module.exports = {
   discontinuityStarts: [],
   mediaSequence: 266,
   preloadSegment: {
+    raw: [
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.0.mp4\",INDEPENDENT=YES',
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.1.mp4\"',
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.2.mp4\"',
+      '#EXT-X-PART:DURATION=0.33334,URI=\"filePart273.3.mp4\"',
+      '#EXT-X-PRELOAD-HINT:TYPE=PART,URI=\"filePart273.4.mp4\"',
+      '#EXT-X-PRELOAD-HINT:TYPE=MAP,URI=\"file-init.mp4\"'
+    ],
     timeline: 0,
     preloadHints: [
       {type: 'PART', uri: 'filePart273.4.mp4'},
@@ -42,16 +50,40 @@ module.exports = {
   segments: [
     {
       duration: 4.00008,
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence269.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence269.mp4'
     },
     {
       duration: 4.00008,
+      raw: [
+        '#EXTINF:4.00008,',
+        'fileSequence270.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence270.mp4'
     },
     {
       duration: 4.00008,
+      raw: [
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.0.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.1.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.2.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.3.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.4.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.5.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.6.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.7.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.8.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.9.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.10.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart271.11.mp4\"',
+        '#EXTINF:4.00008,',
+        'fileSequence271.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence271.mp4',
       parts: [
@@ -111,6 +143,23 @@ module.exports = {
       dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
       dateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
+      raw: [
+        '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:14:00.106Z',
+        '#EXT-X-PART:GAP=YES,DURATION=0.33334,URI=\"filePart272.a.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.b.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.c.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.d.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.e.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.f.mp4\",INDEPENDENT=YES',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.g.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.h.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.i.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.j.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.k.mp4\"',
+        '#EXT-X-PART:DURATION=0.33334,URI=\"filePart272.l.mp4\"',
+        '#EXTINF:4.00008,',
+        'fileSequence272.mp4'
+      ],
       timeline: 0,
       uri: 'fileSequence272.mp4',
       parts: [

--- a/test/fixtures/integration/manifestExtTTargetdurationNegative.js
+++ b/test/fixtures/integration/manifestExtTTargetdurationNegative.js
@@ -4,6 +4,10 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00001.ts'
     }

--- a/test/fixtures/integration/manifestExtXEndlistEarly.js
+++ b/test/fixtures/integration/manifestExtXEndlistEarly.js
@@ -4,26 +4,46 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00002.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00003.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00004.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00004.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00005.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00005.ts'
     }

--- a/test/fixtures/integration/manifestNoExtM3u.js
+++ b/test/fixtures/integration/manifestNoExtM3u.js
@@ -4,6 +4,10 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '/test/ts-files/zencoder/gogo/00001.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/zencoder/gogo/00001.ts'
     }

--- a/test/fixtures/integration/master-fmp4.js
+++ b/test/fixtures/integration/master-fmp4.js
@@ -65,6 +65,10 @@ module.exports = {
       'AUDIO': 'aud1',
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=2165224,BANDWIDTH=2215219,CODECS=\"avc1.640020,mp4a.40.2\",RESOLUTION=960x540,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v4/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v4/prog_index.m3u8'
   },
@@ -83,6 +87,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=7962844,BANDWIDTH=7976430,CODECS=\"avc1.64002a,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v8/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v8/prog_index.m3u8'
   },
@@ -100,6 +108,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=6165024,BANDWIDTH=6181885,CODECS=\"avc1.64002a,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v7/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v7/prog_index.m3u8'
   },
@@ -117,6 +129,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=4664459,BANDWIDTH=4682666,CODECS=\"avc1.64002a,mp4a.40.2\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v6/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v6/prog_index.m3u8'
   },
@@ -134,6 +150,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=3164759,BANDWIDTH=3170746,CODECS=\"avc1.640020,mp4a.40.2\",RESOLUTION=1280x720,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v5/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v5/prog_index.m3u8'
   },
@@ -151,6 +171,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1262552,BANDWIDTH=1276223,CODECS=\"avc1.64001e,mp4a.40.2\",RESOLUTION=768x432,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v3/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v3/prog_index.m3u8'
   },
@@ -168,6 +192,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=893243,BANDWIDTH=904744,CODECS=\"avc1.64001e,mp4a.40.2\",RESOLUTION=640x360,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v2/prog_index.m3u8'
   },
@@ -185,6 +213,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=527673,BANDWIDTH=538201,CODECS=\"avc1.640015,mp4a.40.2\",RESOLUTION=480x270,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud1\",SUBTITLES=\"sub1\"',
+      'v1/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v1/prog_index.m3u8'
   },
@@ -202,6 +234,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=2390334,BANDWIDTH=2440329,CODECS=\"avc1.640020,ac-3\",RESOLUTION=960x540,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v4/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v4/prog_index.m3u8'
   },
@@ -219,6 +255,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=8187954,BANDWIDTH=8201540,CODECS=\"avc1.64002a,ac-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v8/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v8/prog_index.m3u8'
   },
@@ -236,6 +276,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=6390134,BANDWIDTH=6406995,CODECS=\"avc1.64002a,ac-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v7/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v7/prog_index.m3u8'
   },
@@ -253,6 +297,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=4889569,BANDWIDTH=4907776,CODECS=\"avc1.64002a,ac-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v6/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v6/prog_index.m3u8'
   },
@@ -270,6 +318,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=3389869,BANDWIDTH=3395856,CODECS=\"avc1.640020,ac-3\",RESOLUTION=1280x720,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v5/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v5/prog_index.m3u8'
   },
@@ -287,6 +339,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1487662,BANDWIDTH=1501333,CODECS=\"avc1.64001e,ac-3\",RESOLUTION=768x432,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v3/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v3/prog_index.m3u8'
   },
@@ -304,6 +360,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1118353,BANDWIDTH=1129854,CODECS=\"avc1.64001e,ac-3\",RESOLUTION=640x360,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v2/prog_index.m3u8'
   },
@@ -321,6 +381,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=752783,BANDWIDTH=763311,CODECS=\"avc1.640015,ac-3\",RESOLUTION=480x270,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud2\",SUBTITLES=\"sub1\"',
+      'v1/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v1/prog_index.m3u8'
   },
@@ -338,6 +402,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=2198334,BANDWIDTH=2248329,CODECS=\"avc1.640020,ec-3\",RESOLUTION=960x540,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v4/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v4/prog_index.m3u8'
   },
@@ -355,6 +423,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=7995954,BANDWIDTH=8009540,CODECS=\"avc1.64002a,ec-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v8/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v8/prog_index.m3u8'
   },
@@ -372,6 +444,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=6198134,BANDWIDTH=6214995,CODECS=\"avc1.64002a,ec-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v7/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v7/prog_index.m3u8'
   },
@@ -389,6 +465,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=4697569,BANDWIDTH=4715776,CODECS=\"avc1.64002a,ec-3\",RESOLUTION=1920x1080,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v6/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v6/prog_index.m3u8'
   },
@@ -406,6 +486,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=3197869,BANDWIDTH=3203856,CODECS=\"avc1.640020,ec-3\",RESOLUTION=1280x720,FRAME-RATE=59.940,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v5/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v5/prog_index.m3u8'
   },
@@ -423,6 +507,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=1295662,BANDWIDTH=1309333,CODECS=\"avc1.64001e,ec-3\",RESOLUTION=768x432,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v3/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v3/prog_index.m3u8'
   },
@@ -440,6 +528,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=926353,BANDWIDTH=937854,CODECS=\"avc1.64001e,ec-3\",RESOLUTION=640x360,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v2/prog_index.m3u8'
   },
@@ -457,6 +549,10 @@ module.exports = {
       },
       'SUBTITLES': 'sub1'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:AVERAGE-BANDWIDTH=560783,BANDWIDTH=571311,CODECS=\"avc1.640015,ec-3\",RESOLUTION=480x270,FRAME-RATE=29.970,CLOSED-CAPTIONS=\"cc1\",AUDIO=\"aud3\",SUBTITLES=\"sub1\"',
+      'v1/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'v1/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/master.js
+++ b/test/fixtures/integration/master.js
@@ -10,6 +10,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=240000,RESOLUTION=396x224',
+        'media.m3u8'
+      ],
       timeline: 0,
       uri: 'media.m3u8'
     },
@@ -18,6 +22,10 @@ module.exports = {
         'PROGRAM-ID': 1,
         'BANDWIDTH': 40000
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1, BANDWIDTH=40000',
+        'media1.m3u8'
+      ],
       timeline: 0,
       uri: 'media1.m3u8'
     },
@@ -30,6 +38,10 @@ module.exports = {
           height: 224
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=440000,RESOLUTION=396x224',
+        'media2.m3u8'
+      ],
       timeline: 0,
       uri: 'media2.m3u8'
     },
@@ -42,6 +54,10 @@ module.exports = {
           height: 540
         }
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1928000,RESOLUTION=960x540',
+        'media3.m3u8'
+      ],
       timeline: 0,
       uri: 'media3.m3u8'
     }

--- a/test/fixtures/integration/media.js
+++ b/test/fixtures/integration/media.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00001.ts'
+      ],
       timeline: 0,
       uri: 'media-00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00002.ts'
+      ],
       timeline: 0,
       uri: 'media-00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00003.ts'
+      ],
       timeline: 0,
       uri: 'media-00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00004.ts'
+      ],
       timeline: 0,
       uri: 'media-00004.ts'
     }

--- a/test/fixtures/integration/mediaSequence.js
+++ b/test/fixtures/integration/mediaSequence.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/missingEndlist.js
+++ b/test/fixtures/integration/missingEndlist.js
@@ -4,11 +4,19 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '00001.ts'
+      ],
       timeline: 0,
       uri: '00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '00002.ts'
+      ],
       timeline: 0,
       uri: '00002.ts'
     }

--- a/test/fixtures/integration/missingExtinf.js
+++ b/test/fixtures/integration/missingExtinf.js
@@ -5,16 +5,27 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
     {
       duration: 10,
+      raw: [
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/missingMediaSequence.js
+++ b/test/fixtures/integration/missingMediaSequence.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/missingSegmentDuration.js
+++ b/test/fixtures/integration/missingSegmentDuration.js
@@ -5,21 +5,34 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 8,
+      raw: [
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 8,
+      raw: [
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 8,
+      raw: [
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/multipleAudioGroups.js
+++ b/test/fixtures/integration/multipleAudioGroups.js
@@ -55,6 +55,10 @@ module.exports = {
       'CODECS': 'mp4a.40.5',
       'AUDIO': 'audio-lo'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=195023,CODECS=\"mp4a.40.5\", AUDIO=\"audio-lo\"',
+      'lo/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'lo/prog_index.m3u8'
   }, {
@@ -64,6 +68,10 @@ module.exports = {
       'CODECS': 'avc1.42e01e,mp4a.40.2',
       'AUDIO': 'audio-lo'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=260000,CODECS=\"avc1.42e01e,mp4a.40.2\", AUDIO=\"audio-lo\"',
+      'lo2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'lo2/prog_index.m3u8'
   }, {
@@ -73,6 +81,10 @@ module.exports = {
       'CODECS': 'mp4a.40.2, avc1.64001e',
       'AUDIO': 'audio-hi'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=591680,CODECS=\"mp4a.40.2, avc1.64001e\", AUDIO=\"audio-hi\"',
+      'hi/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'hi/prog_index.m3u8'
   }, {
@@ -82,6 +94,10 @@ module.exports = {
       'CODECS': 'avc1.42e01e,mp4a.40.2',
       'AUDIO': 'audio-hi'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=650000,CODECS=\"avc1.42e01e,mp4a.40.2\", AUDIO=\"audio-hi\"',
+      'hi2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'hi2/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/multipleAudioGroupsCombinedMain.js
+++ b/test/fixtures/integration/multipleAudioGroupsCombinedMain.js
@@ -54,6 +54,10 @@ module.exports = {
       'CODECS': 'mp4a.40.5',
       'AUDIO': 'audio-lo'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=195023,CODECS=\"mp4a.40.5\", AUDIO=\"audio-lo\"',
+      'lo/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'lo/prog_index.m3u8'
   }, {
@@ -63,6 +67,10 @@ module.exports = {
       'CODECS': 'avc1.42e01e,mp4a.40.2',
       'AUDIO': 'audio-lo'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=260000,CODECS=\"avc1.42e01e,mp4a.40.2\", AUDIO=\"audio-lo\"',
+      'lo2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'lo2/prog_index.m3u8'
   }, {
@@ -72,6 +80,10 @@ module.exports = {
       'CODECS': 'mp4a.40.2, avc1.64001e',
       'AUDIO': 'audio-hi'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=591680,CODECS=\"mp4a.40.2, avc1.64001e\", AUDIO=\"audio-hi\"',
+      'hi/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'hi/prog_index.m3u8'
   }, {
@@ -81,6 +93,10 @@ module.exports = {
       'CODECS': 'avc1.42e01e,mp4a.40.2',
       'AUDIO': 'audio-hi'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=650000,CODECS=\"avc1.42e01e,mp4a.40.2\", AUDIO=\"audio-hi\"',
+      'hi2/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'hi2/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/multipleTargetDurations.js
+++ b/test/fixtures/integration/multipleTargetDurations.js
@@ -5,21 +5,34 @@ module.exports = {
   segments: [
     {
       uri: '001.ts',
+      raw: [
+        '001.ts'
+      ],
       timeline: 0
     },
     {
       uri: '002.ts',
       duration: 9,
+      raw: [
+        '002.ts'
+      ],
       timeline: 0
     },
     {
       uri: '003.ts',
       duration: 7,
+      raw: [
+        '#EXTINF:7',
+        '003.ts'
+      ],
       timeline: 0
     },
     {
       uri: '004.ts',
       duration: 10,
+      raw: [
+        '004.ts'
+      ],
       timeline: 0
     }
   ],

--- a/test/fixtures/integration/multipleVideo.js
+++ b/test/fixtures/integration/multipleVideo.js
@@ -57,6 +57,10 @@ module.exports = {
       'AUDIO': 'aac',
       'VIDEO': '200kbs'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=300000,CODECS=\"mp4a.40.2,avc1.4d401e\",VIDEO=\"200kbs\",AUDIO=\"aac\"',
+      'Angle1/200kbs/prog_index.m3u'
+    ],
     timeline: 0,
     uri: 'Angle1/200kbs/prog_index.m3u'
   }, {
@@ -67,6 +71,10 @@ module.exports = {
       'AUDIO': 'aac',
       'VIDEO': '500kbs'
     },
+    raw: [
+      '#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=754857,CODECS=\"mp4a.40.2,avc1.4d401e\",VIDEO=\"500kbs\",AUDIO=\"aac\"',
+      'Angle1/500kbs/prog_index.m3u8'
+    ],
     timeline: 0,
     uri: 'Angle1/500kbs/prog_index.m3u8'
   }],

--- a/test/fixtures/integration/negativeMediaSequence.js
+++ b/test/fixtures/integration/negativeMediaSequence.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/playlist.js
+++ b/test/fixtures/integration/playlist.js
@@ -9,6 +9,11 @@ module.exports = {
         offset: 0
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:522828@0',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -18,6 +23,11 @@ module.exports = {
         offset: 522828
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:587500@522828',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -27,6 +37,11 @@ module.exports = {
         offset: 1110328
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:713084@1110328',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -36,6 +51,11 @@ module.exports = {
         offset: 1823412
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:476580@1823412',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -45,6 +65,11 @@ module.exports = {
         offset: 2299992
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:535612@2299992',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -54,6 +79,11 @@ module.exports = {
         offset: 2835604
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:207176@2835604',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -63,6 +93,11 @@ module.exports = {
         offset: 3042780
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:455900@3042780',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -72,6 +107,11 @@ module.exports = {
         offset: 3498680
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:657248@3498680',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -81,6 +121,11 @@ module.exports = {
         offset: 4155928
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:571708@4155928',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -90,6 +135,11 @@ module.exports = {
         offset: 4727636
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:485040@4727636',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -99,6 +149,11 @@ module.exports = {
         offset: 5212676
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:709136@5212676',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -108,6 +163,11 @@ module.exports = {
         offset: 5921812
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:730004@5921812',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -117,6 +177,11 @@ module.exports = {
         offset: 6651816
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:456276@6651816',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -126,6 +191,11 @@ module.exports = {
         offset: 7108092
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:468684@7108092',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -135,6 +205,11 @@ module.exports = {
         offset: 7576776
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:444996@7576776',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -144,6 +219,11 @@ module.exports = {
         offset: 8021772
       },
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '#EXT-X-BYTERANGE:331444@8021772',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
@@ -153,6 +233,11 @@ module.exports = {
         offset: 8353216
       },
       duration: 1.4167,
+      raw: [
+        '#EXTINF:1.4167,',
+        '#EXT-X-BYTERANGE:44556@8353216',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/playlistMediaSequenceHigher.js
+++ b/test/fixtures/integration/playlistMediaSequenceHigher.js
@@ -5,6 +5,10 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     }

--- a/test/fixtures/integration/start.js
+++ b/test/fixtures/integration/start.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00001.ts'
+      ],
       timeline: 0,
       uri: 'media-00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00002.ts'
+      ],
       timeline: 0,
       uri: 'media-00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00003.ts'
+      ],
       timeline: 0,
       uri: 'media-00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'media-00004.ts'
+      ],
       timeline: 0,
       uri: 'media-00004.ts'
     }

--- a/test/fixtures/integration/streamInfInvalid.js
+++ b/test/fixtures/integration/streamInfInvalid.js
@@ -5,10 +5,18 @@ module.exports = {
       attributes: {
         'PROGRAM-ID': 1
       },
+      raw: [
+        '#EXT-X-STREAM-INF:PROGRAM-ID=1',
+        'media.m3u8'
+      ],
       timeline: 0,
       uri: 'media.m3u8'
     },
     {
+      raw: [
+        '#EXT-X-STREAM-INF:',
+        'media1.m3u8'
+      ],
       timeline: 0,
       uri: 'media1.m3u8'
     }

--- a/test/fixtures/integration/twoMediaSequences.js
+++ b/test/fixtures/integration/twoMediaSequences.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 6.64,
+      raw: [
+        '#EXTINF:6.640,{}',
+        '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/8a5e2822668b5370f4eb1438b2564fb7ab12ffe1-hi720.ts'
     },
     {
       duration: 6.08,
+      raw: [
+        '#EXTINF:6.080,{}',
+        '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/56be1cef869a1c0cc8e38864ad1add17d187f051-hi720.ts'
     },
     {
       duration: 6.6,
+      raw: [
+        '#EXTINF:6.600,{}',
+        '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/549c8c77f55f049741a06596e5c1e01dacaa46d0-hi720.ts'
     },
     {
       duration: 5,
+      raw: [
+        '#EXTINF:5.000,{}',
+        '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
+      ],
       timeline: 0,
       uri: '/test/ts-files/tvy7/6cfa378684ffeb1c455a64dae6c103290a1f53d4-hi720.ts'
     }

--- a/test/fixtures/integration/versionInvalid.js
+++ b/test/fixtures/integration/versionInvalid.js
@@ -5,6 +5,10 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'hls_450k_video.ts'
+      ],
       timeline: 0,
       uri: 'hls_450k_video.ts'
     }

--- a/test/fixtures/integration/whiteSpace.js
+++ b/test/fixtures/integration/whiteSpace.js
@@ -5,21 +5,37 @@ module.exports = {
   segments: [
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'http://example.com/00001.ts'
+      ],
       timeline: 0,
       uri: 'http://example.com/00001.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'https://example.com/00002.ts'
+      ],
       timeline: 0,
       uri: 'https://example.com/00002.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        '//example.com/00003.ts'
+      ],
       timeline: 0,
       uri: '//example.com/00003.ts'
     },
     {
       duration: 10,
+      raw: [
+        '#EXTINF:10,',
+        'http://example.com/00004.ts'
+      ],
       timeline: 0,
       uri: 'http://example.com/00004.ts'
     }

--- a/test/fixtures/integration/zeroDuration.js
+++ b/test/fixtures/integration/zeroDuration.js
@@ -5,6 +5,10 @@ module.exports = {
   segments: [
     {
       duration: 0.01,
+      raw: [
+        '#EXTINF:0,',
+        'http://example.com/00001.ts'
+      ],
       timeline: 0,
       uri: 'http://example.com/00001.ts'
     }

--- a/test/parse-stream.test.js
+++ b/test/parse-stream.test.js
@@ -78,7 +78,8 @@ QUnit.test('mapper does not conflict with parser', function(assert) {
   });
   assert.deepEqual(dataCallback.getCall(2).args[0], {
     text: 'SOMETHING-ELSE',
-    type: 'comment'
+    type: 'comment',
+    raw: '#SOMETHING-ELSE'
   });
 });
 
@@ -100,11 +101,13 @@ QUnit.test('maps custom tags', function(assert) {
 
   assert.deepEqual(dataCallback.getCall(0).args[0], {
     text: 'EXAMPLE',
-    type: 'comment'
+    type: 'comment',
+    raw: '#EXAMPLE'
   });
   assert.deepEqual(dataCallback.getCall(1).args[0], {
     text: 'NEW-COMMENT',
-    type: 'comment'
+    type: 'comment',
+    raw: '#NEW-COMMENT'
   });
 });
 
@@ -137,12 +140,14 @@ QUnit.test('maps multiple custom tags', function(assert) {
 
   assert.deepEqual(dataCallback.getCall(0).args[0], {
     text: 'VOD-STARTTIMESTAMP:1501533337573',
-    type: 'comment'
+    type: 'comment',
+    raw: '#VOD-STARTTIMESTAMP:1501533337573'
   });
 
   assert.deepEqual(dataCallback.getCall(1).args[0], {
     text: 'NEW-COMMENT',
-    type: 'comment'
+    type: 'comment',
+    raw: '#NEW-COMMENT'
   });
 
   const dateTag = dataCallback.getCall(2).args[0];
@@ -169,7 +174,8 @@ QUnit.test('mapper ignores tags', function(assert) {
   assert.strictEqual(dataCallback.callCount, 1);
   assert.deepEqual(dataCallback.getCall(0).args[0], {
     text: 'TAG',
-    type: 'comment'
+    type: 'comment',
+    raw: '#TAG'
   });
 });
 
@@ -752,7 +758,8 @@ QUnit.test('parses valid #EXT-X-KEY tags', function(assert) {
     attributes: {
       METHOD: 'AES-128',
       URI: 'https://priv.example.com/key.php?r=52'
-    }
+    },
+    raw: '#EXT-X-KEY:METHOD=AES-128,URI=\"https://priv.example.com/key.php?r=52\"'
   }, 'parsed a valid key');
 
   manifest = '#EXT-X-KEY:URI="https://example.com/key#1",METHOD=FutureType-1024\n';
@@ -764,7 +771,8 @@ QUnit.test('parses valid #EXT-X-KEY tags', function(assert) {
     attributes: {
       METHOD: 'FutureType-1024',
       URI: 'https://example.com/key#1'
-    }
+    },
+    raw: '#EXT-X-KEY:URI=\"https://example.com/key#1\",METHOD=FutureType-1024'
   }, 'parsed the attribute list independent of order');
 
   manifest = '#EXT-X-KEY:IV=1234567890abcdef1234567890abcdef\n';
@@ -790,7 +798,8 @@ QUnit.test('parses minimal #EXT-X-KEY tags', function(assert) {
   assert.ok(element, 'an event was triggered');
   assert.deepEqual(element, {
     type: 'tag',
-    tagType: 'key'
+    tagType: 'key',
+    raw: '#EXT-X-KEY:'
   }, 'parsed a minimal key tag');
 });
 


### PR DESCRIPTION
Feature #49 

Adds raw segment lines to the parsed manifest.

Playlist:
```
#EXTM3U
#EXT-X-PLAYLIST-TYPE:VOD
#EXT-X-TARGETDURATION:10
#EXTINF:10,
media-00001.ts
#EXTINF:10,
media-00002.ts
#EXTINF:10,
media-00003.ts
#EXTINF:10,
media-00004.ts
#EXT-X-ENDLIST
```

Parsed output:
```
{
  allowCache: true,
  mediaSequence: 0,
  playlistType: 'VOD',
  segments: [
    {
      duration: 10,
      raw: [
        '#EXTINF:10,',
        'media-00001.ts'
      ],
      timeline: 0,
      uri: 'media-00001.ts'
    },
    {
      duration: 10,
      raw: [
        '#EXTINF:10,',
        'media-00002.ts'
      ],
      timeline: 0,
      uri: 'media-00002.ts'
    },
    {
      duration: 10,
      raw: [
        '#EXTINF:10,',
        'media-00003.ts'
      ],
      timeline: 0,
      uri: 'media-00003.ts'
    },
    {
      duration: 10,
      raw: [
        '#EXTINF:10,',
        'media-00004.ts'
      ],
      timeline: 0,
      uri: 'media-00004.ts'
    }
  ],
  targetDuration: 10,
  endList: true,
  discontinuitySequence: 0,
  discontinuityStarts: []
}
```