### PR TITLE
feat: add independent-segments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Manifest {
 * [EXT-X-ENDLIST](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.3.4)
 * [EXT-X-PLAYLIST-TYPE](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.3.5)
 * [EXT-X-START](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.2)
+* [EXT-X-INDEPENDENT-SEGMENTS](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.1)
 
 ### Master Playlist Tags
 
@@ -241,7 +242,6 @@ Example media playlist using `EXT-X-CUE-` tags.
 * [EXT-X-I-FRAME-STREAM-INF](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.4.3)
 * [EXT-X-SESSION-DATA](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.4.4)
 * [EXT-X-SESSION-KEY](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.4.5)
-* [EXT-X-INDEPENDENT-SEGMENTS](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.1)
 
 ### Custom Parsers
 

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -616,6 +616,14 @@ export default class ParseStream extends Stream {
         this.trigger('data', event);
         return;
       }
+      match = (/^#EXT-X-INDEPENDENT-SEGMENTS/).exec(newLine);
+      if (match) {
+        this.trigger('data', {
+          type: 'tag',
+          tagType: 'independent-segments'
+        });
+        return;
+      }
 
       // unknown tag type
       this.trigger('data', {

--- a/src/parser.js
+++ b/src/parser.js
@@ -695,6 +695,9 @@ export default class Parser extends Stream {
                   }
                 }
               }
+            },
+            'independent-segments'() {
+              this.manifest.independentSegments = true;
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/fixtures/integration/fmp4.js
+++ b/test/fixtures/integration/fmp4.js
@@ -40,5 +40,6 @@ module.exports = {
     }
   ],
   endList: true,
-  version: 7
+  version: 7,
+  independentSegments: true
 };

--- a/test/fixtures/integration/master-fmp4.js
+++ b/test/fixtures/integration/master-fmp4.js
@@ -461,5 +461,6 @@ module.exports = {
     uri: 'v1/prog_index.m3u8'
   }],
   segments: [],
-  version: 6
+  version: 6,
+  independentSegments: true
 };

--- a/test/parse-stream.test.js
+++ b/test/parse-stream.test.js
@@ -963,6 +963,21 @@ QUnit.test('custom attributes in EXT-X-DATERANGE are parsed', function(assert) {
   assert.ok(element, 'an event was triggered');
   assert.strictEqual(element.attributes['X-CUSTOM-KEY'], '0X12345abcde');
 });
+
+QUnit.test('parses EXT-X-INDEPENDENT-SEGMENTS', function(assert) {
+  const manifest = '#EXT-X-INDEPENDENT-SEGMENTS\n';
+  let element;
+
+  this.parseStream.on('data', function(elem) {
+    element = elem;
+  });
+  this.lineStream.push(manifest);
+
+  assert.ok(element, 'an event was triggered');
+  assert.strictEqual(element.type, 'tag', 'the line type is tag');
+  assert.strictEqual(element.tagType, 'independent-segments', 'the tag type is independent-segments');
+});
+
 QUnit.test('ignores empty lines', function(assert) {
   const manifest = '\n';
   let event = false;

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1056,6 +1056,17 @@ QUnit.module('m3u8s', function(hooks) {
     assert.equal(this.parser.manifest.daterange.length, 3);
   });
 
+  QUnit.test('parses #EXT-X-INDEPENDENT-SEGMENTS', function(assert) {
+    this.parser.push([
+      '#EXTM3U',
+      '#EXT-X-VERSION:6',
+      '#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK=3.252,CAN-SKIP-UNTIL=42.0',
+      '#EXT-X-INDEPENDENT-SEGMENTS'
+    ].join('\n'));
+    this.parser.end();
+    assert.equal(this.parser.manifest.independentSegments, true);
+  });
+
   QUnit.module('integration');
 
   for (const key in testDataExpected) {


### PR DESCRIPTION
Add support for parsing [#EXT-X-INDEPENDENT-SEGMENTS](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.5.1) tags.