### PR TITLE
feat: Add PDT to each segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ var manifest = [
   '0.ts',
   '#EXTINF:6,',
   '1.ts',
+  '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:14:00.106Z'
   '#EXTINF:6,',
   '2.ts',
   '#EXT-X-ENDLIST'
@@ -79,6 +80,7 @@ Manifest {
   allowCache: boolean,
   endList: boolean,
   mediaSequence: number,
+  dateRanges: [],
   discontinuitySequence: number,
   playlistType: string,
   custom: {},
@@ -106,8 +108,6 @@ Manifest {
     'CLOSED-CAPTIONS': {},
     SUBTITLES: {}
   },
-  dateTimeString: string,
-  dateTimeObject: Date,
   targetDuration: number,
   totalDuration: number,
   discontinuityStarts: [number],
@@ -118,6 +118,7 @@ Manifest {
         offset: number
       },
       duration: number,
+      programDateTime:  number,
       attributes: {},
       discontinuity: number,
       uri: string,

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -356,7 +356,6 @@ export default class ParseStream extends Stream {
         };
         if (match[1]) {
           event.dateTimeString = match[1];
-          event.dateTimeObject = new Date(match[1]);
         }
         this.trigger('data', event);
         return;

--- a/src/parser.js
+++ b/src/parser.js
@@ -466,6 +466,7 @@ export default class Parser extends Stream {
               currentUri.dateTimeObject = entry.dateTimeObject;
 
               const { lastProgramDateTime } = this;
+
               // Explicitly set program date time:
               currentUri.programDateTime = new Date(entry.dateTimeObject).getTime();
               this.lastProgramDateTime = currentUri.programDateTime;

--- a/src/parser.js
+++ b/src/parser.js
@@ -467,9 +467,7 @@ export default class Parser extends Stream {
 
               const { lastProgramDateTime } = this;
 
-              // Explicitly set program date time:
-              currentUri.programDateTime = new Date(entry.dateTimeObject).getTime();
-              this.lastProgramDateTime = currentUri.programDateTime;
+              this.lastProgramDateTime = new Date(entry.dateTimeObject).getTime();
 
               // we should extrapolate Program Date Time backward only during firs program date time occurrence.
               // Once we have at least one program date time point, we can always extrapolate it forward using lastProgramDateTime reference.
@@ -745,10 +743,10 @@ export default class Parser extends Stream {
           // reset the last byterange end as it needs to be 0 between parts
           lastPartByterangeEnd = 0;
 
-          // Once we have at least one program date time, and it wasn't set explicitly we can always extrapolate it forward:
-          if (this.lastProgramDateTime !== null && currentUri.programDateTime === undefined) {
-            currentUri.programDateTime = this.lastProgramDateTime + (currentUri.duration * 1000);
-            this.lastProgramDateTime = currentUri.programDateTime;
+          // Once we have at least one program date time we can always extrapolate it forward
+          if (this.lastProgramDateTime !== null) {
+            currentUri.programDateTime = this.lastProgramDateTime;
+            this.lastProgramDateTime += currentUri.duration * 1000;
           }
 
           // prepare for the next URI

--- a/src/parser.js
+++ b/src/parser.js
@@ -126,6 +126,7 @@ export default class Parser extends Stream {
     this.manifest = {
       allowCache: true,
       discontinuityStarts: [],
+      dateRanges: [],
       segments: []
     };
     // keep track of the last seen segment's byte range end, as segments are not required
@@ -640,7 +641,6 @@ export default class Parser extends Stream {
               setHoldBack.call(this, this.manifest);
             },
             'daterange'() {
-              this.manifest.dateRanges = this.manifest.dateRanges || [];
               this.manifest.dateRanges.push(camelCaseKeys(entry.attributes));
               const index = this.manifest.dateRanges.length - 1;
 
@@ -784,7 +784,7 @@ export default class Parser extends Stream {
   end() {
     // flush any buffered input
     this.lineStream.push('\n');
-    if (this.manifest.dateRanges && this.lastProgramDateTime === null) {
+    if (this.manifest.dateRanges.length && this.lastProgramDateTime === null) {
       this.trigger('warn', {
         message: 'A playlist with EXT-X-DATERANGE tag must contain atleast one EXT-X-PROGRAM-DATE-TIME tag'
       });

--- a/src/parser.js
+++ b/src/parser.js
@@ -709,7 +709,6 @@ export default class Parser extends Stream {
               this.manifest.independentSegments = true;
             }
           })[entry.tagType] || noop).call(self);
-          this.addPDTToSegment_();
         },
         uri() {
           currentUri.uri = entry.uri;
@@ -737,6 +736,7 @@ export default class Parser extends Stream {
 
           // prepare for the next URI
           currentUri = {};
+          this.addPDTToSegment_();
         },
         comment() {
           // comments are not important for playback

--- a/src/parser.js
+++ b/src/parser.js
@@ -458,7 +458,7 @@ export default class Parser extends Stream {
 
               this.lastProgramDateTime = new Date(entry.dateTimeString).getTime();
 
-              // we should extrapolate Program Date Time backward only during firs program date time occurrence.
+              // We should extrapolate Program Date Time backward only during first program date time occurrence.
               // Once we have at least one program date time point, we can always extrapolate it forward using lastProgramDateTime reference.
               if (lastProgramDateTime === null) {
                 // Extrapolate Program Date Time backward

--- a/src/parser.js
+++ b/src/parser.js
@@ -453,12 +453,11 @@ export default class Parser extends Stream {
               this.manifest.discontinuityStarts.push(uris.length);
             },
             'program-date-time'() {
-              currentUri.dateTimeString = entry.dateTimeString;
-              currentUri.dateTimeObject = entry.dateTimeObject;
+              currentUri.programDateTimeString = entry.dateTimeString;
 
               const { lastProgramDateTime } = this;
 
-              this.lastProgramDateTime = new Date(entry.dateTimeObject).getTime();
+              this.lastProgramDateTime = new Date(entry.dateTimeString).getTime();
 
               // we should extrapolate Program Date Time backward only during firs program date time occurrence.
               // Once we have at least one program date time point, we can always extrapolate it forward using lastProgramDateTime reference.
@@ -687,7 +686,7 @@ export default class Parser extends Stream {
 
                 this.manifest.dateRanges[index].endDate = new Date(newDateInSeconds);
               }
-              if (dateRange && !('dateTimeString' in currentUri)) {
+              if (dateRange && !('programDateTimeString' in currentUri)) {
                 this.trigger('warn', {
                   message: 'A playlist with EXT-X-DATERANGE tag must contain atleast one EXT-X-PROGRAM-DATE-TIME tag'
                 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -453,8 +453,6 @@ export default class Parser extends Stream {
               this.manifest.discontinuityStarts.push(uris.length);
             },
             'program-date-time'() {
-              currentUri.programDateTimeString = entry.dateTimeString;
-
               const { lastProgramDateTime } = this;
 
               this.lastProgramDateTime = new Date(entry.dateTimeString).getTime();
@@ -686,11 +684,6 @@ export default class Parser extends Stream {
 
                 this.manifest.dateRanges[index].endDate = new Date(newDateInSeconds);
               }
-              if (dateRange && !('programDateTimeString' in currentUri)) {
-                this.trigger('warn', {
-                  message: 'A playlist with EXT-X-DATERANGE tag must contain atleast one EXT-X-PROGRAM-DATE-TIME tag'
-                });
-              }
               if (!dateRangeTags[dateRange.id]) {
                 dateRangeTags[dateRange.id] = dateRange;
               } else {
@@ -791,6 +784,11 @@ export default class Parser extends Stream {
   end() {
     // flush any buffered input
     this.lineStream.push('\n');
+    if (this.manifest.dateRanges && this.lastProgramDateTime === null) {
+      this.trigger('warn', {
+        message: 'A playlist with EXT-X-DATERANGE tag must contain atleast one EXT-X-PROGRAM-DATE-TIME tag'
+      });
+    }
 
     this.lastProgramDateTime = null;
     this.trigger('end');

--- a/src/parser.js
+++ b/src/parser.js
@@ -453,15 +453,6 @@ export default class Parser extends Stream {
               this.manifest.discontinuityStarts.push(uris.length);
             },
             'program-date-time'() {
-              if (typeof this.manifest.dateTimeString === 'undefined') {
-                // PROGRAM-DATE-TIME is a media-segment tag, but for backwards
-                // compatibility, we add the first occurence of the PROGRAM-DATE-TIME tag
-                // to the manifest object
-                // TODO: Consider removing this in future major version
-                this.manifest.dateTimeString = entry.dateTimeString;
-                this.manifest.dateTimeObject = entry.dateTimeObject;
-              }
-
               currentUri.dateTimeString = entry.dateTimeString;
               currentUri.dateTimeObject = entry.dateTimeObject;
 
@@ -696,7 +687,7 @@ export default class Parser extends Stream {
 
                 this.manifest.dateRanges[index].endDate = new Date(newDateInSeconds);
               }
-              if (dateRange && !this.manifest.dateTimeString) {
+              if (dateRange && !('dateTimeString' in currentUri)) {
                 this.trigger('warn', {
                   message: 'A playlist with EXT-X-DATERANGE tag must contain atleast one EXT-X-PROGRAM-DATE-TIME tag'
                 });

--- a/test/fixtures/integration/absoluteUris.js
+++ b/test/fixtures/integration/absoluteUris.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/allowCache.js
+++ b/test/fixtures/integration/allowCache.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: true,
   mediaSequence: 0,
+  dateRanges: [],
   playlistType: 'VOD',
   segments: [
     {

--- a/test/fixtures/integration/allowCacheInvalid.js
+++ b/test/fixtures/integration/allowCacheInvalid.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: true,
   mediaSequence: 0,
+  dateRanges: [],
   playlistType: 'VOD',
   segments: [
     {

--- a/test/fixtures/integration/alternateAudio.js
+++ b/test/fixtures/integration/alternateAudio.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: true,
   discontinuityStarts: [],
+  dateRanges: [],
   mediaGroups: {
     // TYPE
     'AUDIO': {

--- a/test/fixtures/integration/alternateVideo.js
+++ b/test/fixtures/integration/alternateVideo.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: true,
   discontinuityStarts: [],
+  dateRanges: [],
   mediaGroups: {
     'AUDIO': {
       aac: {

--- a/test/fixtures/integration/brightcove.js
+++ b/test/fixtures/integration/brightcove.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   playlists: [
     {
       attributes: {

--- a/test/fixtures/integration/byteRange.js
+++ b/test/fixtures/integration/byteRange.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -4,14 +4,12 @@ module.exports = {
   playlistType: 'VOD',
   segments: [
     {
-      programDateTimeString: '2016-06-22T09:20:16.166-04:00',
       programDateTime: 1466601616166,
       duration: 10,
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
     {
-      programDateTimeString: '2016-06-22T09:20:26.166-04:00',
       programDateTime: 1466601626166,
       duration: 10,
       timeline: 0,

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -22,8 +22,6 @@ module.exports = {
   ],
   targetDuration: 10,
   endList: true,
-  dateTimeString: '2016-06-22T09:20:16.166-04:00',
-  dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
   discontinuitySequence: 0,
   discontinuityStarts: []
 };

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: false,
   mediaSequence: 0,
+  dateRanges: [],
   playlistType: 'VOD',
   segments: [
     {

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -4,16 +4,14 @@ module.exports = {
   playlistType: 'VOD',
   segments: [
     {
-      dateTimeString: '2016-06-22T09:20:16.166-04:00',
-      dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
+      programDateTimeString: '2016-06-22T09:20:16.166-04:00',
       programDateTime: 1466601616166,
       duration: 10,
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
     {
-      dateTimeString: '2016-06-22T09:20:26.166-04:00',
-      dateTimeObject: new Date('2016-06-22T09:20:26.166-04:00'),
+      programDateTimeString: '2016-06-22T09:20:26.166-04:00',
       programDateTime: 1466601626166,
       duration: 10,
       timeline: 0,

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -6,6 +6,7 @@ module.exports = {
     {
       dateTimeString: '2016-06-22T09:20:16.166-04:00',
       dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
+      programDateTime: 1466601616166,
       duration: 10,
       timeline: 0,
       uri: 'hls_450k_video.ts'
@@ -13,6 +14,7 @@ module.exports = {
     {
       dateTimeString: '2016-06-22T09:20:26.166-04:00',
       dateTimeObject: new Date('2016-06-22T09:20:26.166-04:00'),
+      programDateTime: 1466601626166,
       duration: 10,
       timeline: 0,
       uri: 'hls_450k_video.ts'

--- a/test/fixtures/integration/diff-init-key.js
+++ b/test/fixtures/integration/diff-init-key.js
@@ -2,6 +2,7 @@ module.exports = {
   allowCache: true,
   discontinuitySequence: 0,
   discontinuityStarts: [],
+  dateRanges: [],
   mediaSequence: 7794,
   segments: [
     {

--- a/test/fixtures/integration/disallowCache.js
+++ b/test/fixtures/integration/disallowCache.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: false,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/disc-sequence.js
+++ b/test/fixtures/integration/disc-sequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   discontinuitySequence: 3,
   segments: [

--- a/test/fixtures/integration/discontinuity.js
+++ b/test/fixtures/integration/discontinuity.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   discontinuitySequence: 0,
   segments: [

--- a/test/fixtures/integration/domainUris.js
+++ b/test/fixtures/integration/domainUris.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/empty.js
+++ b/test/fixtures/integration/empty.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   segments: []
 };

--- a/test/fixtures/integration/emptyAllowCache.js
+++ b/test/fixtures/integration/emptyAllowCache.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/emptyMediaSequence.js
+++ b/test/fixtures/integration/emptyMediaSequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/emptyPlaylistType.js
+++ b/test/fixtures/integration/emptyPlaylistType.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/emptyTargetDuration.js
+++ b/test/fixtures/integration/emptyTargetDuration.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   playlists: [
     {
       attributes: {

--- a/test/fixtures/integration/encrypted.js
+++ b/test/fixtures/integration/encrypted.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 7794,
   discontinuitySequence: 0,
   discontinuityStarts: [],

--- a/test/fixtures/integration/event.js
+++ b/test/fixtures/integration/event.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'EVENT',
   segments: [

--- a/test/fixtures/integration/extXPlaylistTypeInvalidPlaylist.js
+++ b/test/fixtures/integration/extXPlaylistTypeInvalidPlaylist.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 1,
   segments: [
     {

--- a/test/fixtures/integration/extinf.js
+++ b/test/fixtures/integration/extinf.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/fmp4.js
+++ b/test/fixtures/integration/fmp4.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 1,
   playlistType: 'VOD',
   targetDuration: 6,

--- a/test/fixtures/integration/headerOnly.js
+++ b/test/fixtures/integration/headerOnly.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   segments: []
 };

--- a/test/fixtures/integration/invalidAllowCache.js
+++ b/test/fixtures/integration/invalidAllowCache.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/invalidMediaSequence.js
+++ b/test/fixtures/integration/invalidMediaSequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/invalidPlaylistType.js
+++ b/test/fixtures/integration/invalidPlaylistType.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/invalidTargetDuration.js
+++ b/test/fixtures/integration/invalidTargetDuration.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/liveMissingSegmentDuration.js
+++ b/test/fixtures/integration/liveMissingSegmentDuration.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/liveStart30sBefore.js
+++ b/test/fixtures/integration/liveStart30sBefore.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/llhls-byte-range.js
+++ b/test/fixtures/integration/llhls-byte-range.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 0,

--- a/test/fixtures/integration/llhls-delta-byte-range.js
+++ b/test/fixtures/integration/llhls-delta-byte-range.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 0,

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -36,8 +36,7 @@ module.exports = {
   partTargetDuration: 0.33334,
   segments: [
     {
-      dateTimeObject: new Date('2019-02-14T02:13:36.106Z'),
-      dateTimeString: '2019-02-14T02:13:36.106Z',
+      programDateTimeString: '2019-02-14T02:13:36.106Z',
       programDateTime: 1550110416106,
       duration: 4.00008,
       map: {
@@ -144,8 +143,7 @@ module.exports = {
       ]
     },
     {
-      dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
-      dateTimeString: '2019-02-14T02:14:00.106Z',
+      programDateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       map: {
         uri: 'init.mp4'

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 266,

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -1,7 +1,5 @@
 module.exports = {
   allowCache: true,
-  dateTimeObject: new Date('2019-02-14T02:13:36.106Z'),
-  dateTimeString: '2019-02-14T02:13:36.106Z',
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 266,

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -40,6 +40,7 @@ module.exports = {
     {
       dateTimeObject: new Date('2019-02-14T02:13:36.106Z'),
       dateTimeString: '2019-02-14T02:13:36.106Z',
+      programDateTime: 1550110416106,
       duration: 4.00008,
       map: {
         uri: 'init.mp4'
@@ -52,6 +53,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110420106.08,
       timeline: 0,
       uri: 'fileSequence267.mp4'
     },
@@ -60,6 +62,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110424106.1602,
       timeline: 0,
       uri: 'fileSequence268.mp4'
     },
@@ -68,6 +71,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110428106.2402,
       timeline: 0,
       uri: 'fileSequence269.mp4'
     },
@@ -76,6 +80,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110432106.3203,
       timeline: 0,
       uri: 'fileSequence270.mp4'
     },
@@ -84,6 +89,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110436106.4004,
       timeline: 0,
       uri: 'fileSequence271.mp4',
       parts: [
@@ -146,6 +152,7 @@ module.exports = {
       map: {
         uri: 'init.mp4'
       },
+      programDateTime: 1550110440106,
       timeline: 0,
       uri: 'fileSequence272.mp4',
       parts: [

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -36,7 +36,6 @@ module.exports = {
   partTargetDuration: 0.33334,
   segments: [
     {
-      programDateTimeString: '2019-02-14T02:13:36.106Z',
       programDateTime: 1550110416106,
       duration: 4.00008,
       map: {
@@ -143,7 +142,6 @@ module.exports = {
       ]
     },
     {
-      programDateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       map: {
         uri: 'init.mp4'

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -1,7 +1,5 @@
 module.exports = {
   allowCache: true,
-  dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
-  dateTimeString: '2019-02-14T02:14:00.106Z',
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 266,

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -109,8 +109,7 @@ module.exports = {
       ]
     },
     {
-      dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
-      dateTimeString: '2019-02-14T02:14:00.106Z',
+      programDateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       programDateTime: 1550110440106,
       timeline: 0,

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
   mediaSequence: 266,

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -42,16 +42,19 @@ module.exports = {
   segments: [
     {
       duration: 4.00008,
+      programDateTime: 1550110428105.7598,
       timeline: 0,
       uri: 'fileSequence269.mp4'
     },
     {
       duration: 4.00008,
+      programDateTime: 1550110432105.8398,
       timeline: 0,
       uri: 'fileSequence270.mp4'
     },
     {
       duration: 4.00008,
+      programDateTime: 1550110436105.92,
       timeline: 0,
       uri: 'fileSequence271.mp4',
       parts: [
@@ -111,6 +114,7 @@ module.exports = {
       dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
       dateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
+      programDateTime: 1550110440106,
       timeline: 0,
       uri: 'fileSequence272.mp4',
       parts: [

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -109,7 +109,6 @@ module.exports = {
       ]
     },
     {
-      programDateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       programDateTime: 1550110440106,
       timeline: 0,

--- a/test/fixtures/integration/manifestExtTTargetdurationNegative.js
+++ b/test/fixtures/integration/manifestExtTTargetdurationNegative.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/manifestExtXEndlistEarly.js
+++ b/test/fixtures/integration/manifestExtXEndlistEarly.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/manifestNoExtM3u.js
+++ b/test/fixtures/integration/manifestNoExtM3u.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/master-fmp4.js
+++ b/test/fixtures/integration/master-fmp4.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   mediaGroups: {
     'AUDIO': {

--- a/test/fixtures/integration/master.js
+++ b/test/fixtures/integration/master.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   playlists: [
     {
       attributes: {

--- a/test/fixtures/integration/media.js
+++ b/test/fixtures/integration/media.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/mediaSequence.js
+++ b/test/fixtures/integration/mediaSequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/missingEndlist.js
+++ b/test/fixtures/integration/missingEndlist.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   segments: [
     {

--- a/test/fixtures/integration/missingExtinf.js
+++ b/test/fixtures/integration/missingExtinf.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/missingMediaSequence.js
+++ b/test/fixtures/integration/missingMediaSequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/missingSegmentDuration.js
+++ b/test/fixtures/integration/missingSegmentDuration.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/multipleAudioGroups.js
+++ b/test/fixtures/integration/multipleAudioGroups.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   mediaGroups: {
     'AUDIO': {

--- a/test/fixtures/integration/multipleAudioGroupsCombinedMain.js
+++ b/test/fixtures/integration/multipleAudioGroupsCombinedMain.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   mediaGroups: {
     'AUDIO': {

--- a/test/fixtures/integration/multipleTargetDurations.js
+++ b/test/fixtures/integration/multipleTargetDurations.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   targetDuration: 10,
   segments: [

--- a/test/fixtures/integration/multipleVideo.js
+++ b/test/fixtures/integration/multipleVideo.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   discontinuityStarts: [],
   mediaGroups: {
     'AUDIO': {

--- a/test/fixtures/integration/negativeMediaSequence.js
+++ b/test/fixtures/integration/negativeMediaSequence.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: -11,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/playlist.js
+++ b/test/fixtures/integration/playlist.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/playlistMediaSequenceHigher.js
+++ b/test/fixtures/integration/playlistMediaSequenceHigher.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 17,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/start.js
+++ b/test/fixtures/integration/start.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/streamInfInvalid.js
+++ b/test/fixtures/integration/streamInfInvalid.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   playlists: [
     {
       attributes: {

--- a/test/fixtures/integration/twoMediaSequences.js
+++ b/test/fixtures/integration/twoMediaSequences.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 11,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/versionInvalid.js
+++ b/test/fixtures/integration/versionInvalid.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/whiteSpace.js
+++ b/test/fixtures/integration/whiteSpace.js
@@ -1,5 +1,6 @@
 module.exports = {
   allowCache: true,
+  dateRanges: [],
   mediaSequence: 0,
   playlistType: 'VOD',
   segments: [

--- a/test/fixtures/integration/zeroDuration.js
+++ b/test/fixtures/integration/zeroDuration.js
@@ -1,6 +1,7 @@
 module.exports = {
   allowCache: true,
   mediaSequence: 0,
+  dateRanges: [],
   playlistType: 'VOD',
   segments: [
     {

--- a/test/parse-stream.test.js
+++ b/test/parse-stream.test.js
@@ -635,10 +635,6 @@ QUnit.test(
       element.dateTimeString, '2016-06-22T09:20:16.166-04:00',
       'dateTimeString is parsed'
     );
-    assert.deepEqual(
-      element.dateTimeObject, new Date('2016-06-22T09:20:16.166-04:00'),
-      'dateTimeObject is parsed'
-    );
 
     manifest = '#EXT-X-PROGRAM-DATE-TIME:2016-06-22T09:20:16.16389Z\n';
     this.lineStream.push(manifest);
@@ -649,10 +645,6 @@ QUnit.test(
     assert.strictEqual(
       element.dateTimeString, '2016-06-22T09:20:16.16389Z',
       'dateTimeString is parsed'
-    );
-    assert.deepEqual(
-      element.dateTimeObject, new Date('2016-06-22T09:20:16.16389Z'),
-      'dateTimeObject is parsed'
     );
   }
 );


### PR DESCRIPTION
**Includes BREAKING CHANGES**

The PR
- Adds PDT to each segment with an explicit EXT-PROGRAM-DATE-TIME tag by extrapolating backward when the first EXT-X-PROGRAM-DATE-TIME tag appears after one or more Media Segment URIs and extrapolating forward when subsequent fragments do not have explicit PDT tags 

> If the first EXT-X-PROGRAM-DATE-TIME tag in a Playlist appears after one or more Media Segment URIs, the client SHOULD extrapolate backward from that tag (using EXTINF durations and/or media timestamps) to associate dates with those segments.

> To associate a date with any other Media Segment that does not have an EXT-X-PROGRAM-DATE-TIME tag applied to it directly, the client SHOULD extrapolate forward from the last EXT-X-PROGRAM-DATE-TIME tag appearing before that segment in the Playlist.

- Removes use of PROGRAM-DATE-TIME tag as a manifest object
- Replaces segment PROGRAM-DATE-TIME tag objects `dateTimeString` and `dateTimeObject` with programDateTime 
 


