### PR TITLE
fix: add dateTimeObject and dateTimeString for backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Manifest {
     'CLOSED-CAPTIONS': {},
     SUBTITLES: {}
   },
+  dateTimeString: string,
+  dateTimeObject: Date,
   targetDuration: number,
   totalDuration: number,
   discontinuityStarts: [number],

--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -356,6 +356,7 @@ export default class ParseStream extends Stream {
         };
         if (match[1]) {
           event.dateTimeString = match[1];
+          event.dateTimeObject = new Date(match[1]);
         }
         this.trigger('data', event);
         return;

--- a/src/parser.js
+++ b/src/parser.js
@@ -459,6 +459,17 @@ export default class Parser extends Stream {
               this.manifest.discontinuityStarts.push(uris.length);
             },
             'program-date-time'() {
+              if (typeof this.manifest.dateTimeString === 'undefined') {
+                // PROGRAM-DATE-TIME is a media-segment tag, but for backwards
+                // compatibility, we add the first occurence of the PROGRAM-DATE-TIME tag
+                // to the manifest object
+                // TODO: Consider removing this in future major version
+                this.manifest.dateTimeString = entry.dateTimeString;
+                this.manifest.dateTimeObject = entry.dateTimeObject;
+              }
+              currentUri.dateTimeString = entry.dateTimeString;
+              currentUri.dateTimeObject = entry.dateTimeObject;
+
               const { lastProgramDateTime } = this;
 
               this.lastProgramDateTime = new Date(entry.dateTimeString).getTime();

--- a/test/fixtures/integration/dateTime.js
+++ b/test/fixtures/integration/dateTime.js
@@ -5,12 +5,16 @@ module.exports = {
   playlistType: 'VOD',
   segments: [
     {
+      dateTimeString: '2016-06-22T09:20:16.166-04:00',
+      dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
       programDateTime: 1466601616166,
       duration: 10,
       timeline: 0,
       uri: 'hls_450k_video.ts'
     },
     {
+      dateTimeString: '2016-06-22T09:20:26.166-04:00',
+      dateTimeObject: new Date('2016-06-22T09:20:26.166-04:00'),
       programDateTime: 1466601626166,
       duration: 10,
       timeline: 0,
@@ -19,6 +23,8 @@ module.exports = {
   ],
   targetDuration: 10,
   endList: true,
+  dateTimeString: '2016-06-22T09:20:16.166-04:00',
+  dateTimeObject: new Date('2016-06-22T09:20:16.166-04:00'),
   discontinuitySequence: 0,
   discontinuityStarts: []
 };

--- a/test/fixtures/integration/llhls.js
+++ b/test/fixtures/integration/llhls.js
@@ -1,5 +1,7 @@
 module.exports = {
   allowCache: true,
+  dateTimeObject: new Date('2019-02-14T02:13:36.106Z'),
+  dateTimeString: '2019-02-14T02:13:36.106Z',
   dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
@@ -37,6 +39,8 @@ module.exports = {
   partTargetDuration: 0.33334,
   segments: [
     {
+      dateTimeObject: new Date('2019-02-14T02:13:36.106Z'),
+      dateTimeString: '2019-02-14T02:13:36.106Z',
       programDateTime: 1550110416106,
       duration: 4.00008,
       map: {
@@ -143,6 +147,8 @@ module.exports = {
       ]
     },
     {
+      dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
+      dateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       map: {
         uri: 'init.mp4'

--- a/test/fixtures/integration/llhlsDelta.js
+++ b/test/fixtures/integration/llhlsDelta.js
@@ -1,5 +1,7 @@
 module.exports = {
   allowCache: true,
+  dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
+  dateTimeString: '2019-02-14T02:14:00.106Z',
   dateRanges: [],
   discontinuitySequence: 0,
   discontinuityStarts: [],
@@ -110,6 +112,8 @@ module.exports = {
       ]
     },
     {
+      dateTimeObject: new Date('2019-02-14T02:14:00.106Z'),
+      dateTimeString: '2019-02-14T02:14:00.106Z',
       duration: 4.00008,
       programDateTime: 1550110440106,
       timeline: 0,

--- a/test/parse-stream.test.js
+++ b/test/parse-stream.test.js
@@ -635,6 +635,10 @@ QUnit.test(
       element.dateTimeString, '2016-06-22T09:20:16.166-04:00',
       'dateTimeString is parsed'
     );
+    assert.deepEqual(
+      element.dateTimeObject, new Date('2016-06-22T09:20:16.166-04:00'),
+      'dateTimeObject is parsed'
+    );
 
     manifest = '#EXT-X-PROGRAM-DATE-TIME:2016-06-22T09:20:16.16389Z\n';
     this.lineStream.push(manifest);
@@ -645,6 +649,10 @@ QUnit.test(
     assert.strictEqual(
       element.dateTimeString, '2016-06-22T09:20:16.16389Z',
       'dateTimeString is parsed'
+    );
+    assert.deepEqual(
+      element.dateTimeObject, new Date('2016-06-22T09:20:16.16389Z'),
+      'dateTimeObject is parsed'
     );
   }
 );


### PR DESCRIPTION
Adds `dateTimeObject` and `dateTimeString` back as segment and manifest properties.