### PR TITLE
feat: parse content steering tags and attributes

### DIFF
--- a/src/parse-stream.js
+++ b/src/parse-stream.js
@@ -623,6 +623,16 @@ export default class ParseStream extends Stream {
         });
         return;
       }
+      match = (/^#EXT-X-CONTENT-STEERING:(.*)$/).exec(newLine);
+      if (match) {
+        event = {
+          type: 'tag',
+          tagType: 'content-steering'
+        };
+        event.attributes = parseAttributes(match[1]);
+        this.trigger('data', event);
+        return;
+      }
 
       // unknown tag type
       this.trigger('data', {

--- a/src/parser.js
+++ b/src/parser.js
@@ -704,6 +704,14 @@ export default class Parser extends Stream {
             },
             'independent-segments'() {
               this.manifest.independentSegments = true;
+            },
+            'content-steering'() {
+              this.manifest.contentSteering = camelCaseKeys(entry.attributes);
+              this.warnOnMissingAttributes_(
+                '#EXT-X-CONTENT-STEERING',
+                entry.attributes,
+                ['SERVER-URI']
+              );
             }
           })[entry.tagType] || noop).call(self);
         },

--- a/test/parse-stream.test.js
+++ b/test/parse-stream.test.js
@@ -690,6 +690,14 @@ QUnit.test('parses #EXT-X-STREAM-INF with common attributes', function(assert) {
     'avc1.4d400d, mp4a.40.2',
     'codecs are parsed'
   );
+
+  manifest = '#EXT-X-STREAM-INF:PATHWAY-ID="CDN-A"\n';
+  this.lineStream.push(manifest);
+
+  assert.ok(element, 'an event was triggered');
+  assert.strictEqual(element.type, 'tag', 'the line type is tag');
+  assert.strictEqual(element.tagType, 'stream-inf', 'the tag type is stream-inf');
+  assert.strictEqual(element.attributes['PATHWAY-ID'], 'CDN-A', 'pathway-id is parsed');
 });
 QUnit.test('parses #EXT-X-STREAM-INF with arbitrary attributes', function(assert) {
   const manifest = '#EXT-X-STREAM-INF:NUMERIC=24,ALPHA=Value,MIXED=123abc\n';

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1132,6 +1132,35 @@ QUnit.module('m3u8s', function(hooks) {
     assert.equal(this.parser.manifest.independentSegments, true);
   });
 
+  QUnit.test('parses #EXT-X-CONTENT-STEERING', function(assert) {
+    const expectedContentSteeringObject = {
+      serverUri: '/foo?bar=00012',
+      pathwayId: 'CDN-A'
+    };
+
+    this.parser.push('#EXT-X-CONTENT-STEERING:SERVER-URI="/foo?bar=00012",PATHWAY-ID="CDN-A"');
+    this.parser.end();
+    assert.deepEqual(this.parser.manifest.contentSteering, expectedContentSteeringObject);
+  });
+
+  QUnit.test('parses #EXT-X-CONTENT-STEERING without PATHWAY-ID', function(assert) {
+    const expectedContentSteeringObject = {
+      serverUri: '/bar?foo=00012'
+    };
+
+    this.parser.push('#EXT-X-CONTENT-STEERING:SERVER-URI="/bar?foo=00012"');
+    this.parser.end();
+    assert.deepEqual(this.parser.manifest.contentSteering, expectedContentSteeringObject);
+  });
+
+  QUnit.test('warns on #EXT-X-CONTENT-STEERING missing SERVER-URI', function(assert) {
+    const warning = ['#EXT-X-CONTENT-STEERING lacks required attribute(s): SERVER-URI'];
+
+    this.parser.push('#EXT-X-CONTENT-STEERING:PATHWAY-ID="CDN-A"');
+    this.parser.end();
+    assert.deepEqual(this.warnings, warning, 'warnings as expected');
+  });
+
   QUnit.module('integration');
 
   for (const key in testDataExpected) {


### PR DESCRIPTION
# Feature
Add support for parsing `#EXT-X-CONTENT-STEERING` tags, required `SERVER-URI` property and associated `PATHWAY-ID` attributes.

### References
https://developer.apple.com/streaming/HLSContentSteeringSpecification.pdf
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.6.6