### PR TITLE
chore: add content-steering tag to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Manifest {
 
 * [EXT-X-MEDIA](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.4.1)
 * [EXT-X-STREAM-INF](http://tools.ietf.org/html/draft-pantos-http-live-streaming#section-4.3.4.2)
+* [EXT-X-CONTENT-STEERING](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.6.6)
 
 ### Experimental Tags
 


### PR DESCRIPTION
Add the now supported main manifest tag `EXT-X-CONTENT-STEERING` to the README.md