### PR TITLE
Pass in empty string to URL constructor if no opts.uri defined

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -100,7 +100,7 @@ export default class Parser extends Stream {
     this.parseStream = new ParseStream();
     this.lineStream.pipe(this.parseStream);
     this.mainDefinitions = opts.mainDefinitions || {};
-    this.params = new URL(opts.uri, 'https://a.com').searchParams;
+    this.params = new URL(opts.uri || '', 'https://a.com').searchParams;
     this.lastProgramDateTime = null;
 
     /* eslint-disable consistent-this */


### PR DESCRIPTION
During some routine package updates to our React Native application (which uses `m3u8-parser` internally - thanks for the package!), @timardex found that the minor bump broke a part of our app. We found that the bundled URL implementation behaves differently to browsers when it receives a URL with an `undefined` first argument.

The URL spec says that whatever value is parsed in should be *stringified*, but `undefined` can't be stringified. Browsers / node must just not hit a code path where this is a problem. 

However in our bundled react-native, the URL constructor looks like this: (look at the `// !!!!!PROBLEM HERE!!!` line)
```js
var URL = /*#__PURE__*/function () {
  // $FlowFixMe[missing-local-annot]
  function URL(url, base) {
    _classCallCheck(this, URL);
    this._searchParamsInstance = null;
    var baseUrl = null;
    if (!base || validateBaseUrl(url)) {
      this._url = url;
      if (!this._url.endsWith('/')) {
        this._url += '/';
      }
    } else {
      if (typeof base === 'string') {
        baseUrl = base;
        if (!validateBaseUrl(baseUrl)) {
          throw new TypeError(`Invalid base URL: ${baseUrl}`);
        }
      } else {
        baseUrl = base.toString();
      }
      if (baseUrl.endsWith('/')) {
        baseUrl = baseUrl.slice(0, baseUrl.length - 1);
      }
      // !!!!!PROBLEM HERE!!!!
      if (!url.startsWith('/')) {
        url = `/${url}`;
      }
      if (baseUrl.endsWith(url)) {
        url = '';
      }
      this._url = `${baseUrl}${url}`;
    }
  },
 // Snipped....
}
```

Of course, you can't call `.startsWith` on `undefined`, so this small fix just passes an empty string into the URL constructor if `opts.uri` is `undefined` 

Thanks again for the package, we've worked around it by pinning ourselves to `7.1.0` until this is patched 😄 