### PR TITLE
docs: list the correct type for Segment.key.iv

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Manifest {
       key: {
         method: string,
         uri: string,
-        iv: string
+        iv: Uint32Array
       },
       map: {
         uri: string,


### PR DESCRIPTION
Just a minor documentation fix.

There seems to be a difference between the value type of `iv` in the documentation and the actual code. The code seems to convert the value of `iv`, if it exists, to a `Uint32Array` (seen [here](https://github.com/videojs/m3u8-parser/blob/26d880375e1dec76fe118acfed06657cb4688d7c/src/parse-stream.js#L387-L398)), but the documentation suggests this is a string.

This may have indirectly led to the DefinitelyTyped typings for the project to have the wrong types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72835).

Note: I assume the property's optionality isn't indicated here.