### PR TITLE
fix: add missing comma in README.md code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var manifest = [
   '0.ts',
   '#EXTINF:6,',
   '1.ts',
-  '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:14:00.106Z'
+  '#EXT-X-PROGRAM-DATE-TIME:2019-02-14T02:14:00.106Z',
   '#EXTINF:6,',
   '2.ts',
   '#EXT-X-ENDLIST'


### PR DESCRIPTION
I realized there's a missing comma in the example when I tried to run the code in the browser's developer tools.